### PR TITLE
Fix `wordpress-master` path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Essential development subagents for everyday coding tasks.
 - [**mobile-developer**](categories/01-core-development/mobile-developer.md) - Cross-platform mobile specialist
 - [**ui-designer**](categories/01-core-development/ui-designer.md) - Visual design and interaction specialist
 - [**websocket-engineer**](categories/01-core-development/websocket-engineer.md) - Real-time communication specialist
-- [**wordpress-master**](categories/01-core-development/wordpress-master.md) - WordPress development and optimization expert
+- [**wordpress-master**](categories/08-business-product/wordpress-master.md) - WordPress development and optimization expert
 
 ### [02. Language Specialists](categories/02-language-specialists/)
 Language-specific experts with deep framework knowledge.


### PR DESCRIPTION
Simple Readme update to fix the incorrect path from `categories/01-core-development/` to `categories/08-business-product/` where the file actually resides.