### PR TITLE
feat: add subagent-catalog discovery tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,22 @@ When you add a new agent, you MUST update these files:
    - Follow the standard template structure
    - Include all required sections
 
+### Adding a Tool
+
+Tools are Claude Code skills that enhance the catalog experience (discovery, browsing, management).
+
+1. **Create a folder** in `tools/` with your tool name
+2. **Include required files**:
+   - `README.md` - Installation and usage documentation
+   - Command files (`.md`) - One per command, with YAML frontmatter
+   - Helper scripts (`.sh`, `.py`) - Shared utilities if needed
+3. **Follow skill best practices**:
+   - Use descriptive `name` and `description` in frontmatter
+   - Include trigger phrases in descriptions
+   - Handle errors gracefully with user-friendly messages
+4. **Update the main README.md** - Add your tool to the 🧰 Tools section
+5. **Test locally** before submitting
+
 ### Code of Conduct
 
 - Be respectful and inclusive

--- a/README.md
+++ b/README.md
@@ -329,6 +329,23 @@ Each subagent's `tools` field specifies Claude Code built-in tools, optimized fo
 
 Each agent has minimal necessary permissions. You can extend agents by adding MCP servers or external tools to the `tools` field.
 
+## 🧰 Tools
+
+### [subagent-catalog](tools/subagent-catalog/)
+Claude Code skill for browsing and fetching subagents from this catalog.
+
+| Command | Description |
+|---------|-------------|
+| `/subagent-catalog:search <query>` | Find agents by name, description, or category |
+| `/subagent-catalog:fetch <name>` | Get full agent definition |
+| `/subagent-catalog:list` | Browse all categories |
+| `/subagent-catalog:invalidate` | Refresh cache |
+
+**Installation:**
+```bash
+cp -r tools/subagent-catalog ~/.claude/commands/
+```
+
 ## 🔧 MCP Tools & Resources
 
 If you're using MCP servers with these agents, feel free to add them here.

--- a/tools/subagent-catalog/README.md
+++ b/tools/subagent-catalog/README.md
@@ -1,0 +1,58 @@
+# subagent-catalog
+
+A Claude Code skill for browsing and fetching subagents from the [awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) catalog.
+
+## Installation
+
+Copy the `subagent-catalog/` folder to `~/.claude/commands/`:
+
+```bash
+cp -r tools/subagent-catalog ~/.claude/commands/
+```
+
+## Usage
+
+| Command | Description |
+|---------|-------------|
+| `/subagent-catalog:search <query>` | Find agents by name, description, or category |
+| `/subagent-catalog:fetch <name>` | Get full agent definition |
+| `/subagent-catalog:list` | Browse all categories |
+| `/subagent-catalog:invalidate` | Clear cache (add `--fetch` to refresh immediately) |
+
+## Examples
+
+**Find security-related agents:**
+```
+/subagent-catalog:search security
+```
+
+**Get the code-reviewer definition:**
+```
+/subagent-catalog:fetch code-reviewer
+```
+
+**Browse all available agents:**
+```
+/subagent-catalog:list
+```
+
+## Features
+
+- **Smart caching**: 12-hour TTL with graceful fallback on network failure
+- **Atomic updates**: Uses tmp file + mv pattern to prevent partial writes
+- **Cross-platform**: Works on macOS and Linux
+- **Best practices**: Follows Anthropic skill authoring guidelines
+
+## Cache
+
+- **Location**: `~/.claude/cache/subagent-catalog.md`
+- **TTL**: 12 hours (configurable in `config.sh`)
+- **Behavior**: Auto-refreshes when stale, falls back to old cache on network failure
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Stale results | `/subagent-catalog:invalidate --fetch` |
+| Network error | Check connection, retry |
+| Agent not found | `/subagent-catalog:search <partial-name>` first |

--- a/tools/subagent-catalog/config.sh
+++ b/tools/subagent-catalog/config.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# subagent-catalog configuration
+# shared between search, fetch, and invalidate skills
+
+set -euo pipefail
+
+# --- CONFIG ---
+readonly SUBAGENT_CATALOG_TTL_SECONDS=$((12 * 60 * 60))   # 12 hours
+readonly SUBAGENT_CATALOG_CACHE_FILE="$HOME/.claude/cache/subagent-catalog.md"
+readonly SUBAGENT_CATALOG_REPO_URL="https://raw.githubusercontent.com/VoltAgent/awesome-claude-code-subagents/main"
+
+export SUBAGENT_CATALOG_TTL_SECONDS SUBAGENT_CATALOG_CACHE_FILE SUBAGENT_CATALOG_REPO_URL
+
+# --- HELPERS ---
+
+# get file mtime as epoch seconds
+subagent_catalog_get_mtime() {
+  date -r "$1" +%s
+}
+
+# logging helpers
+subagent_catalog_log_info() { echo "$1"; }
+subagent_catalog_log_error() { echo "ERROR: $1" >&2; }
+
+# format age in human-readable form
+subagent_catalog_format_age() {
+  local seconds=$1
+  if [ $seconds -lt 60 ]; then
+    echo "${seconds}s"
+  elif [ $seconds -lt 3600 ]; then
+    echo "$(( seconds / 60 ))m"
+  else
+    echo "$(( seconds / 3600 ))h"
+  fi
+}
+
+# internal: atomic fetch to cache file
+_subagent_catalog_fetch() {
+  mkdir -p "$(dirname "$SUBAGENT_CATALOG_CACHE_FILE")"
+  if curl -sf --connect-timeout 5 --max-time 30 "$SUBAGENT_CATALOG_REPO_URL/README.md" -o "$SUBAGENT_CATALOG_CACHE_FILE.tmp" 2>/dev/null; then
+    mv "$SUBAGENT_CATALOG_CACHE_FILE.tmp" "$SUBAGENT_CATALOG_CACHE_FILE"
+    return 0
+  else
+    rm -f "$SUBAGENT_CATALOG_CACHE_FILE.tmp"
+    return 1
+  fi
+}
+
+# ensure cache is fresh, with graceful fallback on failure
+subagent_catalog_ensure_cache() {
+  local cache_age=0
+
+  if [ -f "$SUBAGENT_CATALOG_CACHE_FILE" ]; then
+    cache_age=$(( $(date +%s) - $(subagent_catalog_get_mtime "$SUBAGENT_CATALOG_CACHE_FILE") ))
+    if [ $cache_age -lt $SUBAGENT_CATALOG_TTL_SECONDS ]; then
+      subagent_catalog_log_info "using cached catalog ($(subagent_catalog_format_age $cache_age) old)"
+      return 0
+    fi
+  fi
+
+  if _subagent_catalog_fetch; then
+    subagent_catalog_log_info "catalog refreshed"
+  elif [ -f "$SUBAGENT_CATALOG_CACHE_FILE" ]; then
+    subagent_catalog_log_error "fetch failed, using stale cache ($(subagent_catalog_format_age $cache_age) old). try /subagent-catalog:invalidate --fetch"
+  else
+    subagent_catalog_log_error "fetch failed and no cache. check network or try again later"
+    return 1
+  fi
+  return 0
+}
+
+# force refresh cache (for invalidate)
+subagent_catalog_refresh_cache() {
+  if _subagent_catalog_fetch; then
+    subagent_catalog_log_info "cache refreshed"
+    return 0
+  else
+    subagent_catalog_log_error "fetch failed. check network and try again"
+    return 1
+  fi
+}
+
+# invalidate cache
+subagent_catalog_invalidate_cache() {
+  if [ -f "$SUBAGENT_CATALOG_CACHE_FILE" ]; then
+    rm -f "$SUBAGENT_CATALOG_CACHE_FILE"
+    subagent_catalog_log_info "cache invalidated"
+  else
+    subagent_catalog_log_info "cache already empty"
+  fi
+}
+
+# note: functions are available after sourcing, no need to export
+# (export -f causes noisy output in some bash versions)

--- a/tools/subagent-catalog/fetch.md
+++ b/tools/subagent-catalog/fetch.md
@@ -1,0 +1,82 @@
+---
+name: fetch
+description: "Fetch full subagent definition from catalog. Use when user wants to get, download, view, or use a specific subagent."
+---
+
+# Subagent Catalog - Fetch
+
+Get the full definition of a specific agent.
+
+## Input: $ARGUMENTS
+
+Accepts: agent name, path, or GitHub URL.
+
+## Example
+
+```
+/subagent-catalog:fetch code-reviewer
+
+## code-reviewer
+
+**Category**: Quality & Security
+**Tools**: Read, Write, Edit, Bash, Glob, Grep
+
+Expert code reviewer specializing in code quality, security vulnerabilities...
+
+[full definition follows]
+
+---
+**What now?**
+- save to ~/.claude/agents/code-reviewer.md
+- customize for this project
+- spawn as Task subagent
+```
+
+## Instructions
+
+### Progress checklist
+
+Copy and track:
+- [ ] Step 1: Resolve agent path from catalog
+- [ ] Step 2: Fetch full definition
+- [ ] Step 3: Display and offer options
+
+### Step 1: Resolve path
+
+```bash
+source ~/.claude/commands/subagent-catalog/config.sh
+subagent_catalog_ensure_cache
+
+# find the agent (use -F for literal match)
+grep -iF "{{NAME}}" "$SUBAGENT_CATALOG_CACHE_FILE"
+```
+
+Extract path from: `[**name**](path)`
+
+### Step 2: Fetch definition
+
+```bash
+tmp_file=$(mktemp)
+if curl -sf "$SUBAGENT_CATALOG_REPO_URL/{{PATH}}" -o "$tmp_file"; then
+  cat "$tmp_file"
+  rm -f "$tmp_file"
+else
+  rm -f "$tmp_file"
+  subagent_catalog_log_error "failed to fetch. try /subagent-catalog:search first"
+fi
+```
+
+### Step 3: Display and offer options
+
+Show the definition with frontmatter parsed, then offer:
+1. save locally (`~/.claude/agents/<name>.md`)
+2. customize for project
+3. spawn as Task
+
+### Error handling
+
+| error | suggestion |
+|-------|------------|
+| not found | run `/subagent-catalog:search <partial>` |
+| multiple matches | list them, ask user to specify |
+| network error | check connection, retry |

--- a/tools/subagent-catalog/invalidate.md
+++ b/tools/subagent-catalog/invalidate.md
@@ -1,0 +1,47 @@
+---
+name: invalidate
+description: "Invalidate the subagent-catalog cache. Use when results seem stale or user explicitly asks to refresh or clear cache."
+---
+
+# Subagent Catalog - Invalidate
+
+Force-refresh the cached catalog by deleting the local cache file. The next `search` or `fetch` call will pull fresh data from the repository.
+
+## Input: $ARGUMENTS
+
+No arguments required. Optional: pass `--fetch` to immediately refresh after invalidation.
+
+## Instructions
+
+### Step 1: Source config
+
+```bash
+source ~/.claude/commands/subagent-catalog/config.sh
+```
+
+### Step 2: Invalidate (and optionally refresh)
+
+**Invalidate only** (default):
+
+```bash
+subagent_catalog_invalidate_cache
+```
+
+**Invalidate and refresh** (if `$ARGUMENTS` contains `--fetch` or user explicitly asks to refresh):
+
+```bash
+subagent_catalog_invalidate_cache
+subagent_catalog_refresh_cache
+```
+
+### Step 3: Confirm
+
+Report the result:
+- If invalidated only: "cache invalidated. next search/fetch will pull fresh data."
+- If refreshed: "cache invalidated and refreshed with latest catalog."
+
+### When to use
+
+- After the upstream repo has been updated with new subagents
+- If you suspect the cache is corrupted
+- To troubleshoot stale results

--- a/tools/subagent-catalog/list.md
+++ b/tools/subagent-catalog/list.md
@@ -1,0 +1,54 @@
+---
+name: list
+description: "List all categories and agents in the subagent catalog. Use when user wants to see everything available or browse the full catalog."
+---
+
+# Subagent Catalog - List
+
+Browse all available categories and agents from the awesome-claude-code-subagents catalog.
+
+## Input: $ARGUMENTS
+
+No arguments required.
+
+## Instructions
+
+### Step 1: Ensure cache is fresh
+
+```bash
+source ~/.claude/commands/subagent-catalog/config.sh
+subagent_catalog_ensure_cache
+```
+
+### Step 2: Extract and display categories
+
+Parse the catalog and display all categories with their agents:
+
+```bash
+# extract category headers and agent entries
+grep -E "^### \[|^\- \[\*\*" "$SUBAGENT_CATALOG_CACHE_FILE"
+```
+
+### Step 3: Format output
+
+Display as a scannable list:
+
+```
+## Subagent Catalog
+
+### 01. Core Development
+api-designer, backend-developer, frontend-developer, fullstack-developer, ...
+
+### 02. Language Specialists
+typescript-pro, python-pro, rust-engineer, golang-pro, ...
+
+### 03. Infrastructure
+cloud-architect, devops-engineer, kubernetes-specialist, terraform-engineer, ...
+
+[...continue for all 10 categories...]
+```
+
+### Tips
+
+- use `/subagent-catalog:search <query>` to filter by keyword
+- use `/subagent-catalog:fetch <name>` to get full definition

--- a/tools/subagent-catalog/search.md
+++ b/tools/subagent-catalog/search.md
@@ -1,0 +1,58 @@
+---
+name: search
+description: "Search the awesome-claude-code-subagents catalog. Use when user wants to find, discover, or browse available subagents by name, category, or capability."
+---
+
+# Subagent Catalog - Search
+
+Find agents by name, description, or category.
+
+## Input: $ARGUMENTS
+
+## Example output
+
+```
+## Results for "kubernetes"
+
+| Agent | Description |
+|-------|-------------|
+| [kubernetes-specialist](https://github.com/VoltAgent/awesome-claude-code-subagents/blob/main/categories/03-infrastructure/kubernetes-specialist.md) | Container orchestration master |
+| [devops-engineer](https://github.com/VoltAgent/awesome-claude-code-subagents/blob/main/categories/03-infrastructure/devops-engineer.md) | CI/CD and automation expert |
+
+→ use `/subagent-catalog:fetch <name>` to get full definition
+```
+
+## Instructions
+
+### Step 1: Get catalog
+
+```bash
+source ~/.claude/commands/subagent-catalog/config.sh
+subagent_catalog_ensure_cache
+cat "$SUBAGENT_CATALOG_CACHE_FILE"
+```
+
+### Step 2: Match and return
+
+Search the catalog content for matches (case-insensitive substring):
+- agent names
+- descriptions
+- category names
+
+Format each match as a table row with GitHub link.
+
+### Step 3: Handle edge cases
+
+- **no results**: suggest related terms or `/subagent-catalog:list`
+- **too many results**: ask user to narrow the query
+- **category match**: show all agents in that category
+
+## Query examples
+
+| query | matches |
+|-------|---------|
+| `kubernetes` | kubernetes-specialist, devops-engineer |
+| `security` | security-engineer, security-auditor, penetration-tester |
+| `python` | python-pro, django-developer |
+| `review` | code-reviewer, architect-reviewer |
+| `infrastructure` | entire category 03 |


### PR DESCRIPTION
Adds a Claude Code skill for browsing and fetching subagents:
- /subagent-catalog:search - find by keyword
- /subagent-catalog:fetch - get full definition
- /subagent-catalog:list - browse all
- /subagent-catalog:invalidate - cache management

Features:
- 12h TTL cache with graceful fallback
- Follows Anthropic skill best practices
- Cross-platform (macOS + Linux)