### PR TITLE
feat(lang): add Skill tool to all language specialist agents

### DIFF
--- a/categories/02-language-specialists/angular-architect.md
+++ b/categories/02-language-specialists/angular-architect.md
@@ -1,7 +1,7 @@
 ---
 name: angular-architect
 description: "Use when architecting enterprise Angular 15+ applications with complex state management, optimizing RxJS patterns, designing micro-frontend systems, or solving performance and scalability challenges in large codebases."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/cpp-pro.md
+++ b/categories/02-language-specialists/cpp-pro.md
@@ -1,7 +1,7 @@
 ---
 name: cpp-pro
 description: "Use this agent when building high-performance C++ systems requiring modern C++20/23 features, template metaprogramming, or zero-overhead abstractions for systems programming, embedded systems, or performance-critical applications."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/csharp-developer.md
+++ b/categories/02-language-specialists/csharp-developer.md
@@ -1,7 +1,7 @@
 ---
 name: csharp-developer
 description: "Use this agent when building ASP.NET Core web APIs, cloud-native .NET solutions, or modern C# applications requiring async patterns, dependency injection, Entity Framework optimization, and clean architecture."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/django-developer.md
+++ b/categories/02-language-specialists/django-developer.md
@@ -1,7 +1,7 @@
 ---
 name: django-developer
 description: "Use when building Django 4+ web applications, REST APIs, or modernizing existing Django projects with async views and enterprise patterns."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/dotnet-core-expert.md
+++ b/categories/02-language-specialists/dotnet-core-expert.md
@@ -1,7 +1,7 @@
 ---
 name: dotnet-core-expert
 description: "Use when building .NET Core applications requiring cloud-native architecture, high-performance microservices, modern C# patterns, or cross-platform deployment with minimal APIs and advanced ASP.NET Core features."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/dotnet-framework-4.8-expert.md
+++ b/categories/02-language-specialists/dotnet-framework-4.8-expert.md
@@ -1,7 +1,7 @@
 ---
 name: dotnet-framework-4.8-expert
 description: "Use this agent when working on legacy .NET Framework 4.8 enterprise applications that require maintenance, modernization, or integration with Windows-based infrastructure."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/elixir-expert.md
+++ b/categories/02-language-specialists/elixir-expert.md
@@ -1,7 +1,7 @@
 ---
 name: elixir-expert
 description: "Use this agent when you need to build fault-tolerant, concurrent systems leveraging OTP patterns, GenServer architectures, and Phoenix framework for real-time applications."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/flutter-expert.md
+++ b/categories/02-language-specialists/flutter-expert.md
@@ -1,7 +1,7 @@
 ---
 name: flutter-expert
 description: "Use when building cross-platform mobile applications with Flutter 3+ that require custom UI implementation, complex state management, native platform integrations, or performance optimization across iOS/Android/Web."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/golang-pro.md
+++ b/categories/02-language-specialists/golang-pro.md
@@ -1,7 +1,7 @@
 ---
 name: golang-pro
 description: "Use when building Go applications requiring concurrent programming, high-performance systems, microservices, or cloud-native architectures where idiomatic patterns, error handling excellence, and efficiency are critical."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/java-architect.md
+++ b/categories/02-language-specialists/java-architect.md
@@ -1,7 +1,7 @@
 ---
 name: java-architect
 description: "Use this agent when designing enterprise Java architectures, migrating Spring Boot applications, or establishing microservices patterns for scalable cloud-native systems."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/javascript-pro.md
+++ b/categories/02-language-specialists/javascript-pro.md
@@ -1,7 +1,7 @@
 ---
 name: javascript-pro
 description: "Use this agent when you need to build, optimize, or refactor modern JavaScript code for browser, Node.js, or full-stack applications requiring ES2023+ features, async patterns, or performance-critical implementations."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/kotlin-specialist.md
+++ b/categories/02-language-specialists/kotlin-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: kotlin-specialist
 description: "Use when building Kotlin applications requiring advanced coroutine patterns, multiplatform code sharing, or Android/server-side development with functional programming principles."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/laravel-specialist.md
+++ b/categories/02-language-specialists/laravel-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: laravel-specialist
 description: "Use when building Laravel 10+ applications, architecting Eloquent models with complex relationships, implementing queue systems for async processing, or optimizing API performance."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/nextjs-developer.md
+++ b/categories/02-language-specialists/nextjs-developer.md
@@ -1,7 +1,7 @@
 ---
 name: nextjs-developer
 description: "Use this agent when building production Next.js 14+ applications that require full-stack development with App Router, server components, and advanced performance optimization. Invoke when you need to architect or implement complete Next.js applications, optimize Core Web Vitals, implement server actions and mutations, or deploy SEO-optimized applications."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/php-pro.md
+++ b/categories/02-language-specialists/php-pro.md
@@ -1,7 +1,7 @@
 ---
 name: php-pro
 description: "Use this agent when working with PHP 8.3+ projects that require strict typing, modern language features, and enterprise framework expertise (Laravel or Symfony). Use when building scalable applications, optimizing performance, or requiring async/Fiber patterns."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/powershell-5.1-expert.md
+++ b/categories/02-language-specialists/powershell-5.1-expert.md
@@ -1,7 +1,7 @@
 ---
 name: powershell-5.1-expert
 description: "Use when automating Windows infrastructure tasks requiring PowerShell 5.1 scripts with RSAT modules for Active Directory, DNS, DHCP, GPO management, or when building safe, enterprise-grade automation workflows in legacy .NET Framework environments."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/powershell-7-expert.md
+++ b/categories/02-language-specialists/powershell-7-expert.md
@@ -1,7 +1,7 @@
 ---
 name: powershell-7-expert
 description: "Use when building cross-platform cloud automation scripts, Azure infrastructure orchestration, or CI/CD pipelines requiring PowerShell 7+ with modern .NET interop, idempotent operations, and enterprise-grade error handling."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/python-pro.md
+++ b/categories/02-language-specialists/python-pro.md
@@ -1,7 +1,7 @@
 ---
 name: python-pro
 description: "Use this agent when you need to build type-safe, production-ready Python code for web APIs, system utilities, or complex applications requiring modern async patterns and extensive type coverage."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/rails-expert.md
+++ b/categories/02-language-specialists/rails-expert.md
@@ -1,7 +1,7 @@
 ---
 name: rails-expert
 description: "Use when building or modernizing Rails applications requiring full-stack development, Hotwire reactivity, real-time features, or Rails-idiomatic patterns for maximum productivity."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/react-specialist.md
+++ b/categories/02-language-specialists/react-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: react-specialist
 description: "Use when optimizing existing React applications for performance, implementing advanced React 18+ features, or solving complex state management and architectural challenges within React codebases."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/rust-engineer.md
+++ b/categories/02-language-specialists/rust-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: rust-engineer
 description: "Use when building Rust systems where memory safety, ownership patterns, zero-cost abstractions, and performance optimization are critical for systems programming, embedded development, async applications, or high-performance services."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/spring-boot-engineer.md
+++ b/categories/02-language-specialists/spring-boot-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: spring-boot-engineer
 description: "Use this agent when building enterprise Spring Boot 3+ applications requiring microservices architecture, cloud-native deployment, or reactive programming patterns."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/sql-pro.md
+++ b/categories/02-language-specialists/sql-pro.md
@@ -1,7 +1,7 @@
 ---
 name: sql-pro
 description: "Use this agent when you need to optimize complex SQL queries, design efficient database schemas, or solve performance issues across PostgreSQL, MySQL, SQL Server, and Oracle requiring advanced query optimization, index strategies, or data warehouse patterns."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/swift-expert.md
+++ b/categories/02-language-specialists/swift-expert.md
@@ -1,7 +1,7 @@
 ---
 name: swift-expert
 description: "Use this agent when building native iOS, macOS, or server-side Swift applications requiring advanced concurrency patterns, protocol-oriented architecture, and Swift-specific optimizations. Invoke for SwiftUI modernization, async/await implementation, actor-based state management, or memory safety concerns."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/typescript-pro.md
+++ b/categories/02-language-specialists/typescript-pro.md
@@ -1,7 +1,7 @@
 ---
 name: typescript-pro
 description: "Use when implementing TypeScript code requiring advanced type system patterns, complex generics, type-level programming, or end-to-end type safety across full-stack applications."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 

--- a/categories/02-language-specialists/vue-expert.md
+++ b/categories/02-language-specialists/vue-expert.md
@@ -1,7 +1,7 @@
 ---
 name: vue-expert
 description: "Use this agent when building Vue 3 applications that require Composition API mastery, reactivity optimization, or Nuxt 3 development with enterprise-scale performance concerns."
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 model: sonnet
 ---
 


### PR DESCRIPTION
## Summary

- Adds the `Skill` tool to all 26 language specialist agents in `categories/02-language-specialists/`
- One-line change per file: `tools: Read, Write, Edit, Bash, Glob, Grep` → `tools: Read, Write, Edit, Bash, Glob, Grep, Skill`

## Motivation

Claude Code skills now support `context: fork` with an `agent:` field, allowing skills to run inside a specialized subagent. This is a powerful pattern for extending language-specialist agents with project-specific knowledge — a skill provides domain rules and workflow, while the agent brings language expertise.

A common pattern is for the forked skill to call other skills during execution:
- **Reference skills** (e.g., loading framework-specific fixtures, API docs)
- **Validation skills** (e.g., `verification-before-completion` before returning results)

Currently this doesn't work because language specialist agents lack the `Skill` tool in their `tools:` list. The subagent simply cannot invoke `Skill()` — it falls back to reading skill files via `Read`/`Glob`, which bypasses skill activation logic and progressive disclosure.

Adding `Skill` to the tools list is a zero-risk, one-line change that unlocks a major extensibility pattern for these agents.

## Example use case

A plugin defines a skill for running functional tests with project-specific rules:

```yaml
name: testing-functional
agent: voltagent-lang:python-pro
context: fork
```

Inside the skill body:
```
Step 1. Activate Skill(understanding-functional-tests) — load fixtures, patterns, run commands
Step 2. Execute task
Step 3. Run tests (verification loop)
Step 4. Activate Skill(superpowers:verification-before-completion)
Step 5. Return JSON result
```

Without the `Skill` tool, Steps 1 and 4 silently fail — the agent reads raw files instead of activating skills properly.

## Test plan

- [x] Verified that `python-pro` with `Skill` tool successfully calls `Skill(understanding-functional-tests)` and `Skill(superpowers:verification-before-completion)` inside a `context: fork` skill
- [x] Confirmed that without `Skill` tool, the agent falls back to `Read`/`Glob` and misses skill activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)