### PR TITLE
Add Mantra to Developer Experience section

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Tooling and developer productivity experts.
 - [**dx-optimizer**](categories/06-developer-experience/dx-optimizer.md) - Developer experience optimization specialist
 - [**git-workflow-manager**](categories/06-developer-experience/git-workflow-manager.md) - Git workflow and branching expert
 - [**legacy-modernizer**](categories/06-developer-experience/legacy-modernizer.md) - Legacy code modernization specialist
-- [**mantra**](https://github.com/mantra-hq/mantra) - Time-travel debugger for AI coding sessions — replay, branch, and debug Claude Code conversations
+- [**mantra**](https://mantra.gonewx.com) - Time-travel debugger for AI coding sessions — replay, branch, and debug Claude Code conversations ([releases](https://github.com/mantra-hq/mantra-releases))
 - [**mcp-developer**](categories/06-developer-experience/mcp-developer.md) - Model Context Protocol specialist
 - [**powershell-ui-architect**](categories/06-developer-experience/powershell-ui-architect.md) - PowerShell UI/UX specialist for WinForms, WPF, Metro frameworks, and TUIs
 - [**powershell-module-architect**](categories/06-developer-experience/powershell-module-architect.md) - PowerShell module and profile architecture specialist


### PR DESCRIPTION
## Summary

- Adds [Mantra](https://mantra.gonewx.com) to the **Developer Experience** category
- Mantra is a time-travel debugger for AI coding sessions — replay, branch, and debug Claude Code conversations
- Releases: https://github.com/mantra-hq/mantra-releases
- Website: https://mantra.gonewx.com

## Placement

Added alphabetically in the Developer Experience section (between legacy-modernizer and mcp-developer), following the existing format for external tools.