### PR TITLE
fix(plugin-versioning): bump all plugins to 1.0.1 and enforce versio 

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/VoltAgent"
   },
   "metadata": {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Curated collection of 128 specialized Claude Code subagents organized into 10 focused categories"
   },
   "plugins": [
@@ -13,7 +13,7 @@
       "name": "voltagent-core-dev",
       "source": "./categories/01-core-development",
       "description": "Essential development subagents for everyday coding tasks - backend, frontend, fullstack, mobile, and API design",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "development",
       "keywords": ["backend", "frontend", "fullstack", "mobile", "api", "microservices"]
     },
@@ -21,7 +21,7 @@
       "name": "voltagent-lang",
       "source": "./categories/02-language-specialists",
       "description": "Language-specific expert agents with deep framework knowledge - Python, TypeScript, Go, Rust, Java, and more",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "development",
       "keywords": ["python", "typescript", "golang", "rust", "java", "react", "vue", "angular"]
     },
@@ -29,7 +29,7 @@
       "name": "voltagent-infra",
       "source": "./categories/03-infrastructure",
       "description": "DevOps, cloud, and deployment specialists - Kubernetes, Terraform, AWS, Azure, GCP, and SRE",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "infrastructure",
       "keywords": ["devops", "docker", "kubernetes", "terraform", "aws", "azure", "gcp", "sre", "cloud"]
     },
@@ -37,7 +37,7 @@
       "name": "voltagent-qa-sec",
       "source": "./categories/04-quality-security",
       "description": "Testing, security, and code quality experts - code review, penetration testing, QA automation",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "quality",
       "keywords": ["testing", "security", "code-review", "qa", "penetration-testing", "compliance"]
     },
@@ -45,7 +45,7 @@
       "name": "voltagent-data-ai",
       "source": "./categories/05-data-ai",
       "description": "Data engineering, ML, and AI specialists - data pipelines, machine learning, LLM architecture",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "data",
       "keywords": ["data-engineering", "machine-learning", "ai", "llm", "mlops", "nlp"]
     },
@@ -53,7 +53,7 @@
       "name": "voltagent-dev-exp",
       "source": "./categories/06-developer-experience",
       "description": "Tooling and developer productivity experts - CLI tools, documentation, DX optimization",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "tooling",
       "keywords": ["developer-experience", "cli", "documentation", "tooling", "build", "dx"]
     },
@@ -61,7 +61,7 @@
       "name": "voltagent-domains",
       "source": "./categories/07-specialized-domains",
       "description": "Domain-specific technology experts - blockchain, fintech, gaming, IoT, payments",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "specialized",
       "keywords": ["blockchain", "fintech", "gaming", "iot", "payments", "embedded"]
     },
@@ -69,7 +69,7 @@
       "name": "voltagent-biz",
       "source": "./categories/08-business-product",
       "description": "Product management and business analysis - product strategy, project management, UX research",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "business",
       "keywords": ["product-management", "business-analysis", "ux", "scrum", "project-management"]
     },
@@ -77,7 +77,7 @@
       "name": "voltagent-meta",
       "source": "./categories/09-meta-orchestration",
       "description": "Agent coordination and meta-programming - multi-agent orchestration, workflow automation. Works best with other voltagent plugins installed.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "orchestration",
       "keywords": ["multi-agent", "orchestration", "workflow", "coordination", "meta"]
     },
@@ -85,7 +85,7 @@
       "name": "voltagent-research",
       "source": "./categories/10-research-analysis",
       "description": "Research, search, and analysis specialists - market research, competitive analysis, trend forecasting",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "research",
       "keywords": ["research", "analysis", "market-research", "competitive-analysis", "trends"]
     }

--- a/.github/workflows/enforce-plugin-version-bump.yml
+++ b/.github/workflows/enforce-plugin-version-bump.yml
@@ -1,0 +1,81 @@
+name: Enforce Plugin Version Bump
+
+on:
+  pull_request:
+    paths:
+      - "categories/**"
+      - ".claude-plugin/marketplace.json"
+  workflow_dispatch:
+
+jobs:
+  validate-plugin-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate category version bumps and marketplace sync
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+          fi
+
+          if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="$(git rev-list --max-parents=0 HEAD)"
+          fi
+
+          echo "Comparing HEAD with base SHA: ${BASE_SHA}"
+          CHANGED_FILES="$(git diff --name-only "${BASE_SHA}"...HEAD)"
+          FAIL=0
+
+          for plugin_json in categories/*/.claude-plugin/plugin.json; do
+            category_dir="$(dirname "$(dirname "${plugin_json}")")"
+
+            if echo "${CHANGED_FILES}" | grep -Eq "^${category_dir}/.*\.md$"; then
+              if git cat-file -e "${BASE_SHA}:${plugin_json}" 2>/dev/null; then
+                old_version="$(git show "${BASE_SHA}:${plugin_json}" | sed -n 's/.*"version":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+                new_version="$(sed -n 's/.*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "${plugin_json}" | head -n1)"
+
+                if [ "${old_version}" = "${new_version}" ]; then
+                  echo "::error file=${plugin_json}::Markdown changed under ${category_dir}, but plugin version was not bumped (still ${new_version})."
+                  FAIL=1
+                fi
+              fi
+            fi
+          done
+
+          for plugin_json in categories/*/.claude-plugin/plugin.json; do
+            plugin_name="$(sed -n 's/.*"name":[[:space:]]*"\([^"]*\)".*/\1/p' "${plugin_json}" | head -n1)"
+            category_version="$(sed -n 's/.*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "${plugin_json}" | head -n1)"
+
+            marketplace_version="$(
+              awk -v target="${plugin_name}" '
+                $0 ~ "\"name\": \"" target "\"" { in_plugin = 1; next }
+                in_plugin && $0 ~ "\"version\":" {
+                  gsub(/[, "]/, "", $2)
+                  print $2
+                  exit
+                }
+                in_plugin && $0 ~ "}" { in_plugin = 0 }
+              ' .claude-plugin/marketplace.json
+            )"
+
+            if [ -z "${marketplace_version}" ]; then
+              echo "::error file=.claude-plugin/marketplace.json::Could not find plugin ${plugin_name} in marketplace manifest."
+              FAIL=1
+            elif [ "${marketplace_version}" != "${category_version}" ]; then
+              echo "::error file=.claude-plugin/marketplace.json::Version mismatch for ${plugin_name}: marketplace=${marketplace_version}, category=${category_version}."
+              FAIL=1
+            fi
+          done
+
+          if [ "${FAIL}" -ne 0 ]; then
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,18 @@ When you add a new agent, you MUST update these files:
    - Follow the standard template structure
    - Include all required sections
 
+### Versioning Requirements for Plugin Updates
+
+When you modify existing plugin content, you MUST bump versions so users can receive updates via `claude plugin update`.
+
+1. **Bump category plugin version**
+   - File: `categories/<category>/.claude-plugin/plugin.json`
+   - Increment `version` whenever any `*.md` file in that category changes.
+
+2. **Keep marketplace plugin versions in sync**
+   - File: `.claude-plugin/marketplace.json`
+   - Update the corresponding plugin entry version to match the category plugin version.
+
 ### Adding a Tool
 
 Tools are Claude Code skills that enhance the catalog experience (discovery, browsing, management).

--- a/categories/01-core-development/.claude-plugin/plugin.json
+++ b/categories/01-core-development/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-core-dev",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Essential development subagents for everyday coding tasks - backend, frontend, fullstack, mobile, and API design",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/02-language-specialists/.claude-plugin/plugin.json
+++ b/categories/02-language-specialists/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-lang",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Language-specific expert agents with deep framework knowledge - Python, TypeScript, Go, Rust, Java, and more",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/03-infrastructure/.claude-plugin/plugin.json
+++ b/categories/03-infrastructure/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-infra",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "DevOps, cloud, and deployment specialists - Kubernetes, Terraform, AWS, Azure, GCP, and SRE",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/04-quality-security/.claude-plugin/plugin.json
+++ b/categories/04-quality-security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-qa-sec",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Testing, security, and code quality experts - code review, penetration testing, QA automation",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/05-data-ai/.claude-plugin/plugin.json
+++ b/categories/05-data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-data-ai",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Data engineering, ML, and AI specialists - data pipelines, machine learning, LLM architecture",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/06-developer-experience/.claude-plugin/plugin.json
+++ b/categories/06-developer-experience/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-dev-exp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tooling and developer productivity experts - CLI tools, documentation, DX optimization",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/07-specialized-domains/.claude-plugin/plugin.json
+++ b/categories/07-specialized-domains/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-domains",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Domain-specific technology experts - blockchain, fintech, gaming, IoT, payments",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/08-business-product/.claude-plugin/plugin.json
+++ b/categories/08-business-product/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-biz",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Product management and business analysis - product strategy, project management, UX research",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/09-meta-orchestration/.claude-plugin/plugin.json
+++ b/categories/09-meta-orchestration/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-meta",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Agent coordination and meta-programming - multi-agent orchestration, workflow automation. Works best with other voltagent plugins installed.",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/10-research-analysis/.claude-plugin/plugin.json
+++ b/categories/10-research-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-research",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Research, search, and analysis specialists - market research, competitive analysis, trend forecasting",
   "author": {
     "name": "VoltAgent Community",


### PR DESCRIPTION
This PR fixes stale plugin updates by introducing explicit version bumping and enforcement.

## What changed
- Bumped all plugin versions from `1.0.0` to `1.0.1` in:
  - `.claude-plugin/marketplace.json`
  - `categories/*/.claude-plugin/plugin.json`
- Added CI workflow:
  - `.github/workflows/enforce-plugin-version-bump.yml`
- Updated contributor guidance:
  - `CONTRIBUTING.md` with plugin versioning requirements

## Why
Users reported that `claude plugin update` does not pull changed agent markdown files when plugin versions remain unchanged. This caused installed plugins to stay stale even after content updates.

## Enforcement added
- If any `categories/<category>/*.md` file changes, the matching `categories/<category>/.claude-plugin/plugin.json` version must be bumped.
- Category plugin versions must stay in sync with `.claude-plugin/marketplace.json`.

## Expected outcome
- Content changes are now shipped through normal plugin update flow.
- Future PRs that forget version bumps will fail CI, preventing regressions.

Related issue #73