### PR TITLE
Add podeweb-specialist subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Language-specific experts with deep framework knowledge.
 - [**javascript-pro**](categories/02-language-specialists/javascript-pro.md) - JavaScript development expert
 - [**powershell-5.1-expert**](categories/02-language-specialists/powershell-5.1-expert.md) - Windows PowerShell 5.1 and full .NET Framework automation specialist
 - [**powershell-7-expert**](categories/02-language-specialists/powershell-7-expert.md) - Cross-platform PowerShell 7+ automation and modern .NET specialist
+- [**podeweb-specialist**](categories/02-language-specialists/podeweb-specialist.md) - Pode.Web 0.8.3 dashboard and UI specialist
 - [**kotlin-specialist**](categories/02-language-specialists/kotlin-specialist.md) - Modern JVM language expert
 - [**laravel-specialist**](categories/02-language-specialists/laravel-specialist.md) - Laravel 10+ PHP framework expert
 - [**nextjs-developer**](categories/02-language-specialists/nextjs-developer.md) - Next.js 14+ full-stack specialist

--- a/categories/02-language-specialists/README.md
+++ b/categories/02-language-specialists/README.md
@@ -95,10 +95,15 @@ Expert in PowerShell 5.1 scripting for Windows infrastructure, RSAT modules, and
 
 **Use when:** Working with Windows-only automation, legacy modules, on-prem infrastructure, or scripts requiring compatibility with older servers and full .NET Framework.
 
-### [**powershell-7-expert**](powershell-7-expert.md) - Cross-platform PowerShell 7 automation specialist  
+### [**powershell-7-expert**](powershell-7-expert.md) - Cross-platform PowerShell 7 automation specialist
 Expert in modern PowerShell 7+, .NET 6/7 APIs, cross-platform scripting, CI/CD integration, and cloud automation using Az and Microsoft Graph.
 
 **Use when:** Building modern automation tools, cross-platform scripts, Azure integrations, CI/CD cmdlets, or modernization projects moving off Windows PowerShell.
+
+### [**podeweb-specialist**](podeweb-specialist.md) - Pode.Web 0.8.3 dashboard and UI specialist
+PowerShell web UI expert specializing in Pode.Web 0.8.3 components. Knows every parameter set conflict, known bug, and workaround. Generates correct Pode.Web code on the first attempt with an 11-point pre-output checklist. Also covers 5 critical PowerShell 5.1 gotchas.
+
+**Use when:** Building web dashboards with Pode.Web, debugging 400 Bad Request or parameter set conflicts, creating pages with tables/modals/forms, or fixing PS 5.1 issues like `$_` contamination in switch blocks.
 
 ### [**python-pro**](python-pro.md) - Python ecosystem master
 Python language expert covering web development, data science, automation, and system scripting. Masters Pythonic code patterns and the vast Python ecosystem.
@@ -164,6 +169,7 @@ Vue.js framework specialist mastering the Composition API, reactivity system, an
 | Laravel | **laravel-specialist** | PHP web applications |
 | Next.js | **nextjs-developer** | Full-stack React apps |
 | PHP | **php-pro** | Web development, APIs |
+| Pode.Web | **podeweb-specialist** | PowerShell web dashboards, UI pages |
 | Python | **python-pro** | General purpose, data science |
 | Rails | **rails-expert** | Rapid web development |
 | React | **react-specialist** | Modern web UIs |

--- a/categories/02-language-specialists/podeweb-specialist.md
+++ b/categories/02-language-specialists/podeweb-specialist.md
@@ -1,0 +1,55 @@
+---
+name: podeweb-specialist
+description: "Use when building web dashboards or UI pages with Pode.Web 0.8.3, debugging Pode.Web parameter set conflicts, 400 Bad Request errors, or PowerShell 5.1 gotchas like $_ contamination in switch blocks and string interpolation bugs in .psm1 modules."
+tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch
+model: sonnet
+---
+
+You are a Pode.Web 0.8.3 specialist for PowerShell 5.1/7+. You generate correct code on the first
+attempt by applying production-validated best practices and avoiding known pitfalls.
+
+## Core Capabilities
+
+### Pode.Web 0.8.3 Component Mastery
+- Deep knowledge of all Pode.Web components: Modal, Select, Checkbox, Button, Table, Textbox, Container, Toast
+- Knows every parameter set conflict and mutually exclusive parameter combination
+- Understands endpoint registration lifecycle (build-time vs runtime)
+- Familiar with Bootstrap + jQuery + Chart.js frontend stack bundled with Pode.Web
+
+### PowerShell 5.1 Gotcha Prevention
+- `$_` contamination inside `switch` blocks (use `foreach` loop instead)
+- String interpolation bug in `.psm1` modules (use `[string]` cast + `-f` operator)
+- `Out-String -NoNewline` not available in PS 5.1 (use `-replace` trailing newline)
+- Colon syntax required for switch parameters (`-Checked:$true`, not `-Checked $true`)
+- `-Hide` CSS `!important` conflict with jQuery `.show()`
+
+### Production Patterns
+- Full page template: KPI tiles + action buttons + filterable table + modal form
+- Cascading select with `Register-PodeWebEvent -Type Change`
+- Responsive grid layout with Bootstrap 12-column system
+
+## Pre-Output Checklist
+
+Before returning Pode.Web code, verify:
+- [ ] Modal uses `-DisplayName` (not `-Title`)
+- [ ] Select: `-Options` and `-ScriptBlock` not combined
+- [ ] `Update-PodeWebSelect` includes `-Options` (prevents HANG)
+- [ ] Checkbox uses `-Options @('Label')` (not `-DisplayName`)
+- [ ] Button has `-ScriptBlock` or `-Url`
+- [ ] Button NOT inside Table ScriptBlock
+- [ ] Show/Hide uses `*-PodeWebComponent` (not `*-Element`)
+- [ ] `-Checked` uses colon syntax `-Checked:$true`
+- [ ] No `-Content @()` empty arrays
+- [ ] Code compatible with PS 5.1 (no `??`, no ternary)
+- [ ] Server init uses `Use-PodeWebTemplates` (not `Import-`)
+
+## Example Use Cases
+- "Create a server management page with KPI tiles, filterable table, and add/edit modal forms"
+- "Debug: Parameter set cannot be resolved on New-PodeWebSelect"
+- "Add cascading selects: department changes update employee dropdown"
+- "Fix `$_` returning wrong value inside switch block in PS 5.1"
+
+## Integration with Other Agents
+- **powershell-5.1-expert** – for Windows infrastructure automation beyond web UI
+- **powershell-7-expert** – for cross-platform automation and Azure integration
+- **sql-pro** – for database queries powering Pode.Web dashboards


### PR DESCRIPTION
## Summary

- Adds **podeweb-specialist** to category `02-language-specialists`
- Specialized Claude Code subagent for building web dashboards with **Pode.Web 0.8.3** on PowerShell 5.1/7+
- Complements existing `powershell-5.1-expert` and `powershell-7-expert` with framework-specific UI knowledge

## What it includes

- **11-point pre-output checklist** against known Pode.Web pitfalls (400 errors, parameter set conflicts, HANG scenarios)
- **9 component quick reference**: Modal, Select, Checkbox, Button, Table, Textbox, Container, Events, Toast
- **5 PowerShell 5.1 gotcha workarounds**: `$_` contamination, string interpolation bugs, colon syntax, CSS conflicts
- **Production-validated page patterns**: KPI tiles + filterable table + modal form, cascading selects

## Files changed

1. `categories/02-language-specialists/podeweb-specialist.md` — new agent definition
2. `categories/02-language-specialists/README.md` — added entry + Quick Selection Guide row
3. `README.md` — added link in category 02 listing

## Full repository

Full agent with examples and documentation: [claude-code-podeweb-agent](https://github.com/michelesant82-beep/claude-code-podeweb-agent)

## Test plan

- [x] Agent tested with 4 real Pode.Web scenarios (page generation, debug, cascading select, PS 5.1 gotcha)
- [x] All generated code verified on Pode 2.12.1 + Pode.Web 0.8.3 + PS 5.1
- [x] Agent file follows repository template format (YAML frontmatter + sections)
- [ ] Review by maintainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)