### PR TITLE
Add Washin Claude Skills — 112 battle-tested production skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ Claude Code skill for browsing and fetching subagents from this catalog.
 cp -r tools/subagent-catalog ~/.claude/commands/
 ```
 
-
+### [Washin Claude Skills](https://github.com/sstklen/washin-claude-skills)
+112 battle-tested Claude Code skills from 200+ production bugs. Covers Docker/DevOps, API architecture, billing, security, and Hono/Bun patterns. One-command installer with category filtering.
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
Adding [Washin Claude Skills](https://github.com/sstklen/washin-claude-skills) — 112 Claude Code skills extracted from real production incidents.

- One-command installer
- Categories: Docker/DevOps, API architecture, billing patterns, security audits, Hono/Bun
- MIT licensed