### PR TITLE
Add silicon-friendly: AI agent-friendliness checker MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Agent coordination and meta-programming.
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.md) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows
+- [**silicon-friendly**](https://github.com/unlikefraction/silicon-friendly) - MCP server that checks if websites are AI-agent-friendly, rating them on 30 criteria across 5 levels (L1-L5)
 - [**task-distributor**](categories/09-meta-orchestration/task-distributor.md) - Task allocation specialist
 - [**taskade**](https://github.com/taskade/mcp) - AI-powered workspace with autonomous agents, real-time collaboration, and workflow automation with MCP integration
 - [**workflow-orchestrator**](categories/09-meta-orchestration/workflow-orchestrator.md) - Complex workflow automation


### PR DESCRIPTION
## Summary
- Adds [Silicon Friendly](https://github.com/unlikefraction/silicon-friendly) to the Meta & Orchestration category
- Silicon Friendly is an MCP server that Claude Code can use to check if websites are AI-agent-friendly
- Rates websites on 30 criteria across 5 levels (L1-L5)
- MCP endpoint: https://siliconfriendly.com/mcp
- SKILL.md: https://siliconfriendly.com/.well-known/skill.md

## Checklist
- [x] Added to README.md in alphabetical order
- [x] Follows existing format for external entries