### PR TITLE
Add OpenPaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Agent coordination and meta-programming.
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.md) - Knowledge aggregation expert
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration
+- [**openpaw**](https://github.com/daxaur/openpaw) - Personal assistant orchestrator that installs 38 skills (email, calendar, Spotify, smart home, GitHub, etc.) with Telegram bridge, task dashboard, and scheduling
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.md) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows
 - [**task-distributor**](categories/09-meta-orchestration/task-distributor.md) - Task allocation specialist


### PR DESCRIPTION
Adding OpenPaw — it turns Claude Code into a personal assistant by installing 38 skills (email, calendar, Spotify, smart home, GitHub, etc). Also sets up a Telegram bridge, task dashboard, and scheduling with cost caps. Open source, MIT.