### PR TITLE
Add agentskill.sh to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,9 @@ Each agent has minimal necessary permissions. You can extend agents by adding MC
 
 ## 🧰 Tools
 
+### [agentskill.sh](https://agentskill.sh)
+Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
+
 ### [subagent-catalog](tools/subagent-catalog/)
 Claude Code skill for browsing and fetching subagents from this catalog.
 


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Tools section.

agentskill.sh is a directory of 69,000+ AI agent skills with one-click install for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.