### PR TITLE
Add Agent Almanac - 62 subagent definitions library

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Product management and business analysis.
 
 Agent coordination and meta-programming.
 
+- [**agent-almanac**](https://github.com/pjt222/agent-almanac) - Library of 62 subagent definitions spanning development, review, infrastructure, compliance, and specialty domains
 - [**agent-installer**](categories/09-meta-orchestration/agent-installer.md) - Browse and install agents from this repository via GitHub
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.md) - Multi-agent coordinator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.md) - Context optimization expert

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -16,6 +16,12 @@ Use these subagents when you need to:
 
 ## Available Subagents
 
+### [**agent-almanac**](https://github.com/pjt222/agent-almanac) - Library of 62 subagent definitions
+
+Open-source collection of 62 subagent definitions following the [Agent Skills standard](https://agentskills.io). Agents span core development (r-developer, web-developer, shiny-developer), review (senior-researcher, code-reviewer, senior-software-developer), infrastructure (devops-engineer, mlops-engineer), compliance (gxp-validator, auditor, security-analyst), and specialty domains (survivalist, gardener, mycologist). Each agent definition includes tools, skills, model config, and usage scenarios. Also ships 278 skills and 10 team compositions with coordination patterns (hub-and-spoke, sequential, parallel, timeboxed, adaptive).
+
+**Use when:** You need a large library of ready-made subagent definitions to install or reference, want multi-agent team compositions with defined coordination patterns, or are building agent workflows for R package development, compliance validation, or cross-domain projects.
+
 ### [**agent-organizer**](agent-organizer.md) - Multi-agent coordinator
 Orchestration expert managing complex multi-agent collaborations. Masters task decomposition, agent selection, and result synthesis. Turns complex problems into coordinated solutions.
 
@@ -70,6 +76,7 @@ Workflow specialist designing and executing sophisticated AI workflows. Expert i
 
 | If you need to... | Use this subagent |
 |-------------------|-------------------|
+| A library of 62 ready-made agents | **[agent-almanac](https://github.com/pjt222/agent-almanac)** |
 | Coordinate multiple agents | **agent-organizer** |
 | Manage context efficiently | **context-manager** |
 | Handle system errors | **error-coordinator** |


### PR DESCRIPTION
## Summary

- Adds [Agent Almanac](https://github.com/pjt222/agent-almanac) to the **09. Meta & Orchestration** category as an external reference (same pattern as taskade and pied-piper)
- Agent Almanac is an open-source library of **62 subagent definitions** following the [Agent Skills standard](https://agentskills.io)
- Also includes **278 skills** and **10 team compositions** with coordination patterns

## Example agents by category

| Category | Example agents |
|----------|---------------|
| Core development | r-developer, web-developer, shiny-developer, quarto-developer |
| Review | senior-researcher, code-reviewer, senior-software-developer, senior-data-scientist |
| Infrastructure | devops-engineer, mlops-engineer, mcp-developer |
| Compliance | gxp-validator, auditor, security-analyst |
| Specialty | survivalist, gardener, mycologist, dog-trainer |
| Meta-cognitive | mystic, alchemist, shaman |
| Adaptive | shapeshifter, polymath, swarm-strategist |

## Team coordination patterns

hub-and-spoke, sequential, parallel, timeboxed, adaptive, wave-parallel, reciprocal

## Files changed

1. **README.md** - Added entry in 09. Meta & Orchestration section (alphabetical order)
2. **categories/09-meta-orchestration/README.md** - Added detailed description, "Use when" block, and Quick Selection Guide row

No local `.md` agent file since this is an external project (follows the same pattern as taskade and pied-piper).

## Links

- Repository: https://github.com/pjt222/agent-almanac
- Standard: https://agentskills.io