### PR TITLE
Add ORCH — CLI runtime for multi-agent engineering teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Agent coordination and meta-programming.
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.md) - Knowledge aggregation expert
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration
+- [**orch**](https://github.com/oxgeneral/ORCH) - CLI runtime that orchestrates Claude Code, Codex, Cursor, and OpenCode as a typed task queue with state machine (todo→in_progress→review→done), auto-retry, inter-agent messaging, goals system, and TUI dashboard. 1647 tests. MIT TypeScript.
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.md) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows
 - [**task-distributor**](categories/09-meta-orchestration/task-distributor.md) - Task allocation specialist


### PR DESCRIPTION
## Summary

Adds [ORCH](https://github.com/oxgeneral/ORCH) to the **09. Meta & Orchestration** section — same section as `pied-piper` and `taskade`.

## Entry

```
- [**orch**](https://github.com/oxgeneral/ORCH) - CLI runtime that orchestrates Claude Code, Codex, Cursor, and OpenCode as a typed task queue with state machine (todo→in_progress→review→done), auto-retry, inter-agent messaging, goals system, and TUI dashboard. 1647 tests. MIT TypeScript.
```

## Why Meta & Orchestration?

ORCH is a full orchestration runtime for AI agent teams — not a single subagent, but the layer that coordinates multiple Claude Code and other AI agents:

- **State machine** — tasks flow `todo → in_progress → review → done` with mandatory review gate
- **Auto-retry** — agents that fail automatically enter `retrying` state
- **Inter-agent messaging** — `orch msg send / broadcast` for direct agent-to-agent communication
- **Goals system** — high-level goals decomposed into typed task queues
- **Multi-adapter** — Claude Code, Codex, OpenCode, Cursor, shell (5 adapters)
- **TUI dashboard** — Ink/React terminal UI for real-time monitoring
- **npm library** — `@oxgeneral/orch` exports full engine API for programmatic use

Placed alphabetically between `multi-agent-coordinator` and `performance-monitor`.

Similar to how `pied-piper` orchestrates AI subagents for SDLC workflows, ORCH provides the runtime infrastructure for running a full AI engineering team from one CLI.

MIT license, TypeScript strict, 1647 tests.