### PR TITLE
Add healthcare-agents to Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Domain-specific technology experts.
 - [**embedded-systems**](categories/07-specialized-domains/embedded-systems.md) - Embedded and real-time systems expert
 - [**fintech-engineer**](categories/07-specialized-domains/fintech-engineer.md) - Financial technology specialist
 - [**game-developer**](categories/07-specialized-domains/game-developer.md) - Game development expert
+- [**healthcare-agents**](https://github.com/ajhcs/healthcare-agents) - 51 healthcare administration agents with MHA-level expertise across 10 divisions, real regulatory citations (CFR, CMS), and operational templates
 - [**iot-engineer**](categories/07-specialized-domains/iot-engineer.md) - IoT systems developer
 - [**m365-admin**](categories/07-specialized-domains/m365-admin.md) - Microsoft 365, Exchange Online, Teams, and SharePoint administration specialist
 - [**mobile-app-developer**](categories/07-specialized-domains/mobile-app-developer.md) - Mobile application specialist

--- a/categories/07-specialized-domains/README.md
+++ b/categories/07-specialized-domains/README.md
@@ -10,6 +10,7 @@ Use these subagents when you need to:
 - **Create payment systems** with various providers
 - **Build gaming applications** with real-time features
 - **Implement fintech solutions** with compliance
+- **Manage healthcare administration** with regulatory compliance
 - **Develop embedded systems** with hardware constraints
 - **Create mobile applications** with native features
 - **Design financial algorithms** for trading systems
@@ -40,6 +41,11 @@ Fintech expert building secure, compliant financial applications. Masters paymen
 Gaming specialist creating engaging interactive experiences. Expert in game engines, real-time networking, and performance optimization. Builds games that captivate players.
 
 **Use when:** Developing games, implementing game mechanics, optimizing game performance, building multiplayer features, or creating game tools.
+
+### [**healthcare-agents**](https://github.com/ajhcs/healthcare-agents) - Healthcare administration specialists
+Collection of 51 healthcare administration agents with MHA-level expertise across 10 divisions including revenue cycle, compliance, quality, clinical operations, payer relations, and health IT. Features real regulatory citations (CFR, CMS) and operational templates for healthcare organizations.
+
+**Use when:** Managing healthcare revenue cycles, ensuring HIPAA/CMS compliance, optimizing clinical operations, handling payer relations, implementing health IT systems, or navigating healthcare regulatory requirements.
 
 ### [**iot-engineer**](iot-engineer.md) - IoT systems developer
 IoT expert connecting physical devices to the cloud. Masters device protocols, edge computing, and IoT platforms. Creates scalable solutions for the Internet of Things.
@@ -80,6 +86,7 @@ SEO expert driving organic traffic through search optimization. Masters technica
 | Embedded/IoT | **embedded-systems** | Firmware, microcontrollers |
 | Financial Tech | **fintech-engineer** | Banking, payments, compliance |
 | Gaming | **game-developer** | Game engines, multiplayer |
+| Healthcare Admin | **healthcare-agents** | Revenue cycle, compliance, clinical ops |
 | IoT/Connected | **iot-engineer** | Device clouds, sensors |
 | Mobile Apps | **mobile-app-developer** | iOS/Android apps |
 | Payments | **payment-integration** | Payment gateways, PCI |
@@ -106,6 +113,12 @@ SEO expert driving organic traffic through search optimization. Masters technica
 - **fintech-engineer** for financial features
 - **risk-manager** for security
 - **api-documenter** for integration
+
+**Healthcare Organization:**
+- **healthcare-agents** for administration and compliance
+- **risk-manager** for risk assessment
+- **api-documenter** for health IT integrations
+- **fintech-engineer** for billing and revenue cycle
 
 **Gaming Platform:**
 - **game-developer** for game logic


### PR DESCRIPTION
## Summary

- Adds [healthcare-agents](https://github.com/ajhcs/healthcare-agents) to the **07. Specialized Domains** category
- 51 healthcare administration AI agents with MHA-level expertise across 10 divisions (revenue cycle, compliance, quality, clinical operations, payer relations, health IT, and more)
- Features real regulatory citations (CFR, CMS) and operational templates
- Updates both the main README.md and the category README.md (description, Quick Selection Guide, Common Domain Patterns)

## Changes

- **README.md**: Added `healthcare-agents` entry in Specialized Domains (alphabetical order)
- **categories/07-specialized-domains/README.md**: Added full description, "When to Use" entry, Quick Selection Guide row, and Healthcare Organization domain pattern

## Test plan

- [ ] Verify all links resolve correctly
- [ ] Confirm alphabetical ordering is maintained
- [ ] Check formatting consistency with existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)