### PR TITLE
Add AgenTopology — multi-agent topology designer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Agent coordination and meta-programming.
 
 - [**agent-installer**](categories/09-meta-orchestration/agent-installer.md) - Browse and install agents from this repository via GitHub
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.md) - Multi-agent coordinator
+- [**agentopology**](https://github.com/agentopology/agentopology) - Declarative language and skill for designing multi-agent teams — type `/agentopology`, describe your team in plain English, and it generates the full topology (agents, flows, gates, hooks, group chats, MCP servers) with interactive graph visualization and scaffolding to 7 platforms (Claude Code, OpenClaw, Cursor, Codex, Gemini, Copilot, Kiro)
 - [**context-manager**](categories/09-meta-orchestration/context-manager.md) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.md) - Error handling and recovery specialist
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist


### PR DESCRIPTION
## Summary

- Adds [AgenTopology](https://github.com/agentopology/agentopology) to the **09. Meta & Orchestration** category
- AgenTopology is a declarative language and Claude Code skill (`/agentopology`) for designing multi-agent teams — describe your team in plain English and it generates the full topology (agents, flows, gates, hooks, group chats, MCP servers) with interactive graph visualization and scaffolding to 7 platforms (Claude Code, OpenClaw, Cursor, Codex, Gemini, Copilot, Kiro)

## Checklist

- [x] Entry follows the existing format (`[**name**](url) - description`)
- [x] Placed in alphabetical order within the category
- [x] Link points to a public GitHub repository