### PR TITLE
Add skillfold to Meta & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Agent coordination and meta-programming.
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.md) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows
+- [**skillfold**](https://github.com/byronxlg/skillfold) - YAML pipeline compiler for multi-agent teams with typed state, skill composition, and team flows
 - [**task-distributor**](categories/09-meta-orchestration/task-distributor.md) - Task allocation specialist
 - [**taskade**](https://github.com/taskade/mcp) - AI-powered workspace with autonomous agents, real-time collaboration, and workflow automation with MCP integration
 - [**workflow-orchestrator**](categories/09-meta-orchestration/workflow-orchestrator.md) - Complex workflow automation


### PR DESCRIPTION
**[engineer]**

## Description

Adds [skillfold](https://github.com/byronxlg/skillfold) to the **09. Meta & Orchestration** category.

**Entry added:**
- [**skillfold**](https://github.com/byronxlg/skillfold) - YAML pipeline compiler for multi-agent teams with typed state, skill composition, and team flows

## What is skillfold?

Skillfold is a configuration language and compiler for multi-agent AI pipelines. It compiles YAML config into standard SKILL.md files, supporting:

- **Skill composition** - Atomic skills define reusable fragments; composed skills concatenate them in declared order
- **Typed state schema** - Custom types, primitives, lists, and external locations with read/write validation
- **Team flow** - Agents wired into typed execution graphs with conditional routing, loops, and parallel map
- **Claude Code integration** - `--target claude-code` output mode generating `.claude/agents/*.md` and `.claude/skills/{name}/SKILL.md`
- **Plugin packaging** - `skillfold plugin` for distributable Claude Code plugins

Published on npm as `skillfold`. MIT licensed.

## Checklist

- [x] Entry added to Main README.md in alphabetical order within Meta and Orchestration section
- [x] Format matches existing external entries (link to GitHub repo, not local .md file)
- [x] Description is concise and descriptive
