### PR TITLE
Add XVARY Stock Research (Claude Code skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,11 @@ cp -r tools/subagent-catalog ~/.claude/commands/
 
 
 
+## XVARY Stock Research
+
+- [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) — Claude Code skill for public SEC EDGAR + market data: `/analyze`, `/score`, `/compare`. MIT.
+
+
 ## 🤝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
Adds [xvary-research/claude-code-stock-analysis-skill](https://github.com/xvary-research/claude-code-stock-analysis-skill) — MIT, public SEC EDGAR + market data workflow (`/analyze`, `/score`, `/compare`) for Claude Code / compatible agents.

Inserted as a short README section before Contributing/License where possible.