### PR TITLE
feat: upgrade research agents from haiku to sonnet

### DIFF
--- a/categories/10-research-analysis/competitive-analyst.md
+++ b/categories/10-research-analysis/competitive-analyst.md
@@ -2,7 +2,7 @@
 name: competitive-analyst
 description: "Use when you need to analyze direct and indirect competitors, benchmark against market leaders, or develop strategies to strengthen competitive positioning and market advantage."
 tools: Read, Grep, Glob, WebFetch, WebSearch
-model: haiku
+model: sonnet
 ---
 
 You are a senior competitive analyst with expertise in gathering and analyzing competitive intelligence. Your focus spans competitor monitoring, strategic analysis, market positioning, and opportunity identification with emphasis on providing actionable insights that drive competitive strategy and market success.

--- a/categories/10-research-analysis/data-researcher.md
+++ b/categories/10-research-analysis/data-researcher.md
@@ -2,7 +2,7 @@
 name: data-researcher
 description: "Use this agent when you need to discover, collect, and validate data from multiple sources to fuel analysis and decision-making. Invoke this agent for identifying data sources, gathering raw datasets, performing quality checks, and preparing data for downstream analysis or modeling."
 tools: Read, Grep, Glob, WebFetch, WebSearch
-model: haiku
+model: sonnet
 ---
 
 You are a senior data researcher with expertise in discovering and analyzing data from multiple sources. Your focus spans data collection, cleaning, analysis, and visualization with emphasis on uncovering hidden patterns and delivering data-driven insights that drive strategic decisions.

--- a/categories/10-research-analysis/market-researcher.md
+++ b/categories/10-research-analysis/market-researcher.md
@@ -2,7 +2,7 @@
 name: market-researcher
 description: "Use this agent when you need to analyze markets, understand consumer behavior, assess competitive landscapes, and size opportunities to inform business strategy and market entry decisions."
 tools: Read, Grep, Glob, WebFetch, WebSearch
-model: haiku
+model: sonnet
 ---
 
 You are a senior market researcher with expertise in comprehensive market analysis and consumer behavior research. Your focus spans market dynamics, customer insights, competitive landscapes, and trend identification with emphasis on delivering actionable intelligence that drives business strategy and growth.

--- a/categories/10-research-analysis/search-specialist.md
+++ b/categories/10-research-analysis/search-specialist.md
@@ -2,7 +2,7 @@
 name: search-specialist
 description: "Use when you need to find specific information across multiple sources using advanced search strategies, query optimization, and targeted information retrieval. Invoke this agent when the priority is locating precise, relevant results efficiently rather than analyzing or synthesizing content."
 tools: Read, Grep, Glob, WebFetch, WebSearch
-model: haiku
+model: sonnet
 ---
 
 You are a senior search specialist with expertise in advanced information retrieval and knowledge discovery. Your focus spans search strategy design, query optimization, source selection, and result curation with emphasis on finding precise, relevant information efficiently across any domain or source type.

--- a/categories/10-research-analysis/trend-analyst.md
+++ b/categories/10-research-analysis/trend-analyst.md
@@ -2,7 +2,7 @@
 name: trend-analyst
 description: "Use when analyzing emerging patterns, predicting industry shifts, or developing future scenarios to inform strategic planning and competitive positioning."
 tools: Read, Grep, Glob, WebFetch, WebSearch
-model: haiku
+model: sonnet
 ---
 
 You are a senior trend analyst with expertise in detecting and analyzing emerging trends across industries and domains. Your focus spans pattern recognition, future forecasting, impact assessment, and strategic foresight with emphasis on helping organizations stay ahead of change and capitalize on emerging opportunities.


### PR DESCRIPTION
## Problem

5 out of 7 research agents in `categories/10-research-analysis/` default to `model: haiku`, while the other 2 (research-analyst and scientific-literature-researcher) already use `model: sonnet`. This inconsistency means most research tasks run on a weaker model.

I noticed this when using competitive-analyst and market-researcher - the output quality was noticeably lower than research-analyst for similar tasks. Haiku is great for simple stuff but research and analysis really needs the better reasoning from Sonnet.

## What I changed

Updated `model: haiku` to `model: sonnet` in these 5 agents:

| Agent | Before | After |
|-------|--------|-------|
| competitive-analyst | haiku | sonnet |
| data-researcher | haiku | sonnet |
| market-researcher | haiku | sonnet |
| search-specialist | haiku | sonnet |
| trend-analyst | haiku | sonnet |

Now all 7 research agents are consistent on sonnet.

## Why sonnet for research

Research tasks involve synthesizing findings from multiple sources, identifying patterns in data, and producing structured analysis - all things where Sonnet's stronger reasoning helps a lot. The two agents that already used sonnet (research-analyst and scientific-literature-researcher) seem to agree with this.

Users who prefer haiku for cost reasons can still override it in their local config.

Closes #136