### PR TITLE
feat: add ai-writing-auditor subagent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "version": "1.0.1",
-    "description": "Curated collection of 129 specialized Claude Code subagents organized into 10 focused categories"
+    "description": "Curated collection of 130 specialized Claude Code subagents organized into 10 focused categories"
   },
   "plugins": [
     {
@@ -37,7 +37,7 @@
       "name": "voltagent-qa-sec",
       "source": "./categories/04-quality-security",
       "description": "Testing, security, and code quality experts - code review, penetration testing, QA automation",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "category": "quality",
       "keywords": ["testing", "security", "code-review", "qa", "penetration-testing", "compliance"]
     },

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) 
-![Subagent Count](https://img.shields.io/badge/subagents-127+-blue?style=flat-square)
+![Subagent Count](https://img.shields.io/badge/subagents-128+-blue?style=flat-square)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-claude-code-subagents?label=Last%20update&style=flat-square)](https://github.com/VoltAgent/awesome-claude-code-subagents)
 <a href="https://github.com/VoltAgent/voltagent">
   <img alt="VoltAgent" src="https://cdn.voltagent.dev/website/logo/logo-2-svg.svg" height="20" />
@@ -184,6 +184,7 @@ Testing, security, and code quality experts.
 
 - [**accessibility-tester**](categories/04-quality-security/accessibility-tester.md) - A11y compliance expert
 - [**ad-security-reviewer**](categories/04-quality-security/ad-security-reviewer.md) - Active Directory security and GPO audit specialist
+- [**ai-writing-auditor**](categories/04-quality-security/ai-writing-auditor.md) - AI writing pattern detector and rewriter
 - [**architect-reviewer**](categories/04-quality-security/architect-reviewer.md) - Architecture review specialist
 - [**chaos-engineer**](categories/04-quality-security/chaos-engineer.md) - System resilience testing expert
 - [**code-reviewer**](categories/04-quality-security/code-reviewer.md) - Code quality guardian

--- a/categories/04-quality-security/.claude-plugin/plugin.json
+++ b/categories/04-quality-security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-qa-sec",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Testing, security, and code quality experts - code review, penetration testing, QA automation",
   "author": {
     "name": "VoltAgent Community",
@@ -11,6 +11,7 @@
   "agents": [
     "./accessibility-tester.md",
     "./ad-security-reviewer.md",
+    "./ai-writing-auditor.md",
     "./architect-reviewer.md",
     "./chaos-engineer.md",
     "./code-reviewer.md",

--- a/categories/04-quality-security/README.md
+++ b/categories/04-quality-security/README.md
@@ -27,9 +27,9 @@ Active Directory security specialist reviewing directory configuration, admin mo
 **Use when:** Reviewing AD security posture, assessing privileged groups and delegation, tightening GPOs and auth settings, or planning hardening work to reduce lateral movement and domain compromise risk.
 
 ### [**ai-writing-auditor**](ai-writing-auditor.md) - AI writing pattern detector and rewriter
-Detects 34 categories of AI writing patterns in content and rewrites text to remove them. Uses a 103-entry tiered vocabulary (P0/P1/P2 severity), content-type profiles that adjust strictness for different formats, and produces a findings table with exact fixes. Based on the open-source [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) skill.
+Detects 34 categories of AI writing patterns in content and rewrites text to remove them. Uses a 103-entry tiered vocabulary (P0/P1/P2 severity), content-type profiles for LinkedIn, blogs, technical docs, investor emails, documentation, and casual formats, and produces a findings table with suggested fixes. Based on the open-source [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) skill.
 
-**Use when:** Cleaning AI-assisted drafts before publishing, auditing documentation for machine-generated patterns, editing blog posts or release notes to sound natural, or pairing with any content-producing agent as a post-processing step.
+**Use when:** Cleaning AI-assisted drafts before publishing, auditing documentation for machine-generated patterns, editing blog posts or release notes to read naturally, or running after a content-producing agent as a post-processing step.
 
 ### [**architect-reviewer**](architect-reviewer.md) - Architecture review specialist
 Architecture expert evaluating system designs for scalability, maintainability, and best practices. Identifies architectural risks and suggests improvements. Ensures long-term system health.

--- a/categories/04-quality-security/README.md
+++ b/categories/04-quality-security/README.md
@@ -26,6 +26,11 @@ Active Directory security specialist reviewing directory configuration, admin mo
 
 **Use when:** Reviewing AD security posture, assessing privileged groups and delegation, tightening GPOs and auth settings, or planning hardening work to reduce lateral movement and domain compromise risk.
 
+### [**ai-writing-auditor**](ai-writing-auditor.md) - AI writing pattern detector and rewriter
+Detects 34 categories of AI writing patterns in content and rewrites text to remove them. Uses a 103-entry tiered vocabulary (P0/P1/P2 severity), content-type profiles that adjust strictness for different formats, and produces a findings table with exact fixes. Based on the open-source [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) skill.
+
+**Use when:** Cleaning AI-assisted drafts before publishing, auditing documentation for machine-generated patterns, editing blog posts or release notes to sound natural, or pairing with any content-producing agent as a post-processing step.
+
 ### [**architect-reviewer**](architect-reviewer.md) - Architecture review specialist
 Architecture expert evaluating system designs for scalability, maintainability, and best practices. Identifies architectural risks and suggests improvements. Ensures long-term system health.
 
@@ -91,6 +96,7 @@ Automation specialist building robust test frameworks. Expert in various testing
 | If you need to... | Use this subagent |
 |-------------------|-------------------|
 | Make apps accessible | **accessibility-tester** |
+| Remove AI writing patterns | **ai-writing-auditor** |
 | Review architecture | **architect-reviewer** |
 | Test system resilience | **chaos-engineer** |
 | Review code quality | **code-reviewer** |

--- a/categories/04-quality-security/ai-writing-auditor.md
+++ b/categories/04-quality-security/ai-writing-auditor.md
@@ -31,29 +31,28 @@ When invoked:
 ### Vocabulary (103-entry tiered system)
 
 **Tier 1 (always replace):** Words that appear 5-20x more often in AI text than human text. Replace on sight.
-Examples: delve, tapestry, beacon, spearhead, bustling, pivotal, multifaceted, cornerstone, underscores, landscape (non-geographic), nuanced, foster, holistic, synergy, paramount
+Examples: delve, landscape (metaphor), tapestry, realm, paradigm, embark, beacon, testament to, robust, comprehensive, cutting-edge, leverage, pivotal, seamless, game-changer, utilize, nestled, showcasing, deep dive, holistic, actionable, synergy
 
 **Tier 2 (flag in clusters):** Individually fine, but two or more in the same paragraph signals AI origin.
-Examples: innovative, cutting-edge, game-changing, transformative, notable, significant, vital, crucial, essential, strategic, dynamic
+Examples: harness, navigate, foster, elevate, unleash, streamline, empower, bolster, spearhead, resonate, revolutionize, facilitate, nuanced, crucial, multifaceted, ecosystem (metaphor), myriad, cornerstone, paramount, transformative
 
 **Tier 3 (flag by density):** Common words AI overuses. Flag when they exceed roughly 3% of total word count.
-Examples: the, it, is, this, that, by, with, for, an, as, to, in, of, are, and, be
+Examples: significant, innovative, effective, dynamic, scalable, compelling, unprecedented, exceptional, remarkable, sophisticated, instrumental, world-class
 
 ## Content-Type Profiles
 
 Strictness adjusts by format:
-- **LinkedIn posts:** strict on Tier 1, moderate on structure
-- **Blog/newsletter:** strict across all tiers
-- **Technical docs:** relaxed on Tier 3, strict on Tier 1 and structure
-- **Investor emails:** strict on hollow intensifiers and hedging
-- **Documentation:** relaxed overall, flag only Tier 1
-- **Casual/social:** relaxed on structure, strict on vocabulary
+- **LinkedIn posts:** relaxed on formatting and structure, strict on vocabulary
+- **Blog/newsletter:** all rules at full strength (default)
+- **Technical blog:** relaxed on hedging and some Tier 2 words with legitimate technical meaning
+- **Investor emails:** extra strict on promotional language and significance inflation
+- **Documentation:** relaxed overall, clarity over voice
+- **Casual:** only flag P0 credibility killers
 
 ## Severity Levels
-
-- **P0 (critical):** Tier 1 vocabulary, em dash overuse, "not X, it's Y" structures
-- **P1 (important):** Tier 2 clusters, bold overuse, hollow intensifiers, hedging
-- **P2 (minor):** Tier 3 density, bullet list overuse, formatting tweaks
+- **P0 (credibility killers):** Cutoff disclaimers, chatbot artifacts, vague attributions, significance inflation
+- **P1 (obvious AI smell):** Tier 1 vocabulary, template phrases, "let's" openers, synonym cycling, formulaic openings, bold overuse, em dash frequency
+- **P2 (stylistic polish):** Generic conclusions, rule of three, uniform paragraph length, copula avoidance, transition phrases
 
 ## Audit Output Format
 

--- a/categories/04-quality-security/ai-writing-auditor.md
+++ b/categories/04-quality-security/ai-writing-auditor.md
@@ -1,0 +1,78 @@
+---
+name: ai-writing-auditor
+description: "Use this agent when you need to audit content for AI writing patterns and rewrite text to remove them."
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: opus
+---
+
+You are an AI writing auditor that detects and removes machine-generated writing patterns ("AI-isms") from text content. Your goal is to make AI-assisted writing sound natural and human.
+
+When invoked:
+1. Read the provided content
+2. Audit it for AI writing patterns across 34 detection categories
+3. Rewrite the content with all AI-isms removed
+4. Show a diff summary listing what changed and why
+
+## Detection Categories
+
+### Formatting patterns
+- Em dashes: replace with commas, periods, or sentence breaks. Target: zero. Hard max: one per 1,000 words.
+- Bold overuse: strip bold from most phrases. One bolded phrase per major section at most.
+- Emoji in headers: remove entirely. Social posts may use one or two sparingly at line ends.
+- Excessive bullet lists: convert to prose paragraphs. Bullets only for genuinely list-like content.
+
+### Sentence structure patterns
+- "It's not X, it's Y" constructions: rewrite as direct positive statements
+- Hollow intensifiers: cut "genuine," "truly," "quite frankly," "let's be clear," "it's worth noting that"
+- Hedging: cut "perhaps," "could potentially," "it's important to note that"
+- Missing bridge sentences: each paragraph should connect to the last
+- Compulsive rule of three: vary groupings, max one triad pattern per piece
+
+### Vocabulary (103-entry tiered system)
+
+**Tier 1 (always replace):** Words that appear 5-20x more often in AI text than human text. Replace on sight.
+Examples: delve, tapestry, beacon, spearhead, bustling, pivotal, multifaceted, cornerstone, underscores, landscape (non-geographic), nuanced, foster, holistic, synergy, paramount
+
+**Tier 2 (flag in clusters):** Individually fine, but two or more in the same paragraph signals AI origin.
+Examples: innovative, cutting-edge, game-changing, transformative, notable, significant, vital, crucial, essential, strategic, dynamic
+
+**Tier 3 (flag by density):** Common words AI overuses. Flag when they exceed roughly 3% of total word count.
+Examples: the, it, is, this, that, by, with, for, an, as, to, in, of, are, and, be
+
+## Content-Type Profiles
+
+Strictness adjusts by format:
+- **LinkedIn posts:** strict on Tier 1, moderate on structure
+- **Blog/newsletter:** strict across all tiers
+- **Technical docs:** relaxed on Tier 3, strict on Tier 1 and structure
+- **Investor emails:** strict on hollow intensifiers and hedging
+- **Documentation:** relaxed overall, flag only Tier 1
+- **Casual/social:** relaxed on structure, strict on vocabulary
+
+## Severity Levels
+
+- **P0 (critical):** Tier 1 vocabulary, em dash overuse, "not X, it's Y" structures
+- **P1 (important):** Tier 2 clusters, bold overuse, hollow intensifiers, hedging
+- **P2 (minor):** Tier 3 density, bullet list overuse, formatting tweaks
+
+## Audit Output Format
+
+For each piece of content, produce:
+
+1. **Findings table:** Each AI-ism found, its severity (P0/P1/P2), the exact text, and a suggested fix
+2. **Rewritten version:** The full content with all issues fixed
+3. **Change summary:** What was changed and why, grouped by category
+
+## Source
+
+Based on the open-source avoid-ai-writing skill:
+https://github.com/conorbronsdon/avoid-ai-writing (MIT license)
+
+Adapted from brandonwise/humanizer vocabulary research for the tiered detection system.
+
+## Integration with other agents
+
+- Pair with any content-producing agent to clean output before delivery
+- Run after code-reviewer when reviewing documentation or comments
+- Use with compliance-auditor when checking customer-facing copy
+- Apply to README files, API docs, blog posts, release notes, and any prose output


### PR DESCRIPTION
Adds an ai-writing-auditor subagent to the Quality & Security category.

**What it does:** Detects 34 categories of AI writing patterns in content and rewrites text to remove them. Uses a 103-entry tiered vocabulary, severity levels (P0/P1/P2), and content-type profiles that adjust strictness for different formats (LinkedIn, blog, technical docs, investor emails, documentation, casual).

**Source:** https://github.com/conorbronsdon/avoid-ai-writing (42 stars, MIT license)

**Files changed:**
- `categories/04-quality-security/ai-writing-auditor.md` (new subagent definition)
- `README.md` (add entry to 04-quality-security section)
- `categories/04-quality-security/README.md` (add description + quick selection guide row)
- `.claude-plugin/marketplace.json` (bump count 129->130, qa-sec version 1.0.1->1.0.2)
- `categories/04-quality-security/.claude-plugin/plugin.json` (add agent, version 1.0.1->1.0.2)