### PR TITLE
Add launch-swarm to Meta & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Agent coordination and meta-programming.
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.md) - Error handling and recovery specialist
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.md) - Knowledge aggregation expert
+- [**launch-swarm**](https://github.com/harshmoney123/launch-swarm) - 6-agent Claude Code swarm with strict role separation, dual-gate merge pipeline, and prompt health anti-rot. Agents plan, code, review, document, and deploy autonomously.
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.md) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows


### PR DESCRIPTION
Adds [launch-swarm](https://github.com/harshmoney123/launch-swarm) to the **09. Meta & Orchestration** section.

**launch-swarm** is a 6-agent Claude Code swarm with strict role separation, dual-gate merge pipeline, and prompt health anti-rot. Agents plan, code, review, document, and deploy autonomously.

- Placed in alphabetical order between `knowledge-synthesizer` and `multi-agent-coordinator`
- Follows the existing entry format