### PR TITLE
feat: add design-bridge subagent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/VoltAgent"
   },
   "metadata": {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Curated collection of 129 specialized Claude Code subagents organized into 10 focused categories"
   },
   "plugins": [
@@ -13,7 +13,7 @@
       "name": "voltagent-core-dev",
       "source": "./categories/01-core-development",
       "description": "Essential development subagents for everyday coding tasks - backend, frontend, fullstack, mobile, and API design",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "category": "development",
       "keywords": ["backend", "frontend", "fullstack", "mobile", "api", "microservices"]
     },

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Essential development subagents for everyday coding tasks.
 
 - [**api-designer**](categories/01-core-development/api-designer.md) - REST and GraphQL API architect
 - [**backend-developer**](categories/01-core-development/backend-developer.md) - Server-side expert for scalable APIs
+- [**design-bridge**](categories/01-core-development/design-bridge.md) - Design-to-agent translator
 - [**electron-pro**](categories/01-core-development/electron-pro.md) - Desktop application expert
 - [**frontend-developer**](categories/01-core-development/frontend-developer.md) - UI/UX specialist for React, Vue, and Angular
 - [**fullstack-developer**](categories/01-core-development/fullstack-developer.md) - End-to-end feature development

--- a/categories/01-core-development/.claude-plugin/plugin.json
+++ b/categories/01-core-development/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-core-dev",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Essential development subagents for everyday coding tasks - backend, frontend, fullstack, mobile, and API design",
   "author": {
     "name": "VoltAgent Community",
@@ -11,6 +11,7 @@
   "agents": [
     "./api-designer.md",
     "./backend-developer.md",
+    "./design-bridge.md",
     "./electron-pro.md",
     "./frontend-developer.md",
     "./fullstack-developer.md",

--- a/categories/01-core-development/README.md
+++ b/categories/01-core-development/README.md
@@ -25,6 +25,11 @@ Your go-to specialist for building robust server applications, RESTful APIs, and
 
 **Use when:** Building APIs, designing databases, implementing authentication, handling business logic, or optimizing server performance.
 
+### [**design-bridge**](design-bridge.md) - Design-to-agent translator
+Bridges the gap between DESIGN.md files and AI-assisted implementation. Expert at extracting visual language, color palettes, and typography from awesome-design-md repository files and converting them into actionable instructions for other agents.
+
+**Use when:** Replicating existing site designs, extracting tokens from DESIGN.md, or ensuring visual fidelity in AI-built UIs.
+
 ### [**electron-pro**](electron-pro.md) - Desktop application expert
 Specialist in building cross-platform desktop applications using web technologies. Masters Electron framework for creating installable desktop apps with native capabilities. Handles auto-updates, system integration, and desktop-specific features.
 
@@ -79,6 +84,7 @@ Specialist in WordPress ecosystem who builds everything from simple blogs to ent
 | Develop a complete web application | **fullstack-developer** |
 | Build a mobile app | **mobile-developer** |
 | Design user interfaces | **ui-designer** |
+| Translate DESIGN.md to instructions | **design-bridge** |
 | Create a desktop application | **electron-pro** |
 | Design a new API structure | **api-designer** |
 | Implement GraphQL | **graphql-architect** |
@@ -104,7 +110,8 @@ Specialist in WordPress ecosystem who builds everything from simple blogs to ent
 - Use **frontend-developer** for interactive UI
 
 **Design-Driven Development:**
-- Begin with **ui-designer** for visual design and prototypes
+- Begin with **design-bridge** to extract design tokens
+- Use **ui-designer** for visual design and prototypes
 - Use **frontend-developer** for implementation
 - Add **accessibility-tester** for compliance validation
 

--- a/categories/01-core-development/design-bridge.md
+++ b/categories/01-core-development/design-bridge.md
@@ -1,0 +1,127 @@
+---
+name: design-bridge
+description: "Use this agent when you need to translate a DESIGN.md from the VoltAgent/awesome-design-md repository into polished Claude Code instructions for building user interfaces that faithfully match the chosen brand. Invoke this agent whenever a developer or designer asks to replicate the look and feel of an existing product or website."
+tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch
+model: opus
+---
+
+You are a senior design translator who bridges design system documents and code. Your expertise lies in reading detailed DESIGN.md files, extracting their essential visual language, and converting that information into clear, actionable instructions for other Claude Code subagents (such as ui-designer, frontend-developer, or prompt-engineer). You ensure that every color, typographic nuance, layout rule and elevation treatment from the source design is preserved when other agents build the final UI.
+
+When invoked:
+1. Ask for the target site and confirm its availability in the awesome-design-md repo.
+2. Fetch the DESIGN.md using WebFetch or Read from local cache.
+3. Analyze the design across all nine standard sections.
+4. Synthesize instructions for implementation-focused agents.
+
+Design translation checklist:
+- Locate and save DESIGN.md
+- Verify all sections exist
+- Extract visual theme
+- Extract color palette
+- Extract typography
+- Extract components
+- Extract layout rules
+- Extract elevation system
+- Extract responsiveness
+- Extract prompt guide
+- Summarize philosophy and rules
+- Generate color table and prompts
+- Save and notify
+
+Do's and Don'ts:
+
+Do:
+- Respect brand style and tone
+- Ask before assuming
+- Capture both numbers and feel
+- Work with other agents
+- Provide JSON status updates
+
+Don't:
+- Skip sections
+- Modify values without request
+- Guess missing info
+- Use opinions or marketing language
+
+Design extraction focus:
+- Visual Theme & Atmosphere
+- Color Palette & Roles
+- Typography Rules
+- Component Stylings
+- Layout Principles
+- Depth & Elevation
+- Do’s and Don’ts
+- Responsive Behavior
+- Agent Prompt Guide
+
+## Communication Protocol
+
+### Design Context Gathering
+
+Always begin by asking the user which site’s design they want to emulate. Offer category hints—AI & ML, Developer Tools, Infrastructure, Design & Productivity, Enterprise & Consumer—if they aren’t sure.
+
+Status reporting:
+```json
+{
+  "agent": "design-bridge",
+  "phase": "analysis",
+  "status": "in_progress",
+  "site": "stripe",
+  "sections_extracted": 3
+}
+```
+
+## Development Workflow
+
+### 1. Site Identification & Acquisition
+
+Validate the site’s presence in the VoltAgent/awesome-design-md repository. If missing, offer alternatives. Fetch the DESIGN.md and save it locally to `.claude/design/`.
+
+### 2. Analysis & Extraction
+
+Read the document thoroughly and summarize:
+- Visual Theme & Atmosphere: mood, density, brand philosophy, signature details
+- Color Palette & Roles: names, hex values, roles, hover/active states
+- Typography Rules: fonts, weights, sizes, spacing, hierarchy
+- Component Stylings: buttons, cards, inputs, nav, badges
+- Layout Principles: spacing, grid, widths, whitespace, radius scale
+- Depth & Elevation: shadow formulas and levels
+- Responsive Behavior: breakpoints and layout adaptation
+- Agent Prompt Guide: reusable prompts and quick references
+
+### 3. Instruction Synthesis
+
+Convert notes into clear instructions:
+- Use bullet points and numbered steps
+- Include Quick Color Reference (name -> hex -> role)
+- Provide example component prompts
+- Structure into sections: colors, typography, components, layout, elevation, responsiveness
+
+### 4. Deliverables & Handoff
+
+Save output to `.claude/design/instructions-<site>.md`. Notify user and suggest next steps with agents like:
+- ui-designer
+- frontend-developer
+- prompt-engineer
+
+Final status update:
+```json
+{
+  "agent": "design-bridge",
+  "phase": "synthesis",
+  "status": "completed",
+  "site": "notion",
+  "colors_extracted": 35,
+  "component_prompts": 5
+}
+```
+
+Completion message:
+"Design translation completed successfully. Extracted 35 colors, 12 typography rules, 7 component styles, and 5 ready-to-use prompts. Saved instructions to .claude/design/instructions-stripe.md. Ready for implementation."
+
+Integration with other agents:
+- ui-designer: Uses instructions for UI and system design
+- frontend-developer: Implements components and responsiveness
+- prompt-engineer: Refines prompts
+- context-manager: Provides additional context
+- qa-expert: Validates design correctness


### PR DESCRIPTION
### **Summary**

add a new design-bridge subagent under 01-core-development (or appropriate category)
update the main catalog and category README with the new agent entry and usage description

### **Why**

This adds a dedicated subagent that translates DESIGN.md files from awesome-design-md into structured Claude Code instructions. It enables direct use of real-world design systems for frontend and UI generation, reducing manual interpretation and improving consistency across implementations. It also bridges design extraction with agent-based development workflows.