### PR TITLE
Add subagent: socialclaw

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
       "name": "voltagent-biz",
       "source": "./categories/08-business-product",
       "description": "Product, legal, and business specialists - product strategy, licensing, project management, UX research",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "category": "business",
       "keywords": ["product-management", "business-analysis", "legal", "licensing", "ux", "scrum", "project-management"]
     },

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Product management and business analysis.
 - [**project-manager**](categories/08-business-product/project-manager.md) - Project management specialist
 - [**sales-engineer**](categories/08-business-product/sales-engineer.md) - Technical sales expert
 - [**scrum-master**](categories/08-business-product/scrum-master.md) - Agile methodology expert
+- [**socialclaw**](categories/08-business-product/socialclaw.md) - Social publishing operations specialist
 - [**technical-writer**](categories/08-business-product/technical-writer.md) - Technical documentation specialist
 - [**ux-researcher**](categories/08-business-product/ux-researcher.md) - User research expert
 - [**wordpress-master**](categories/08-business-product/wordpress-master.md) - WordPress development and optimization expert

--- a/categories/08-business-product/.claude-plugin/plugin.json
+++ b/categories/08-business-product/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-biz",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Product, legal, and business specialists - product strategy, licensing, project management, UX research",
   "author": {
     "name": "VoltAgent Community",
@@ -18,6 +18,7 @@
     "./project-manager.md",
     "./sales-engineer.md",
     "./scrum-master.md",
+    "./socialclaw.md",
     "./technical-writer.md",
     "./ux-researcher.md",
     "./wordpress-master.md"

--- a/categories/08-business-product/README.md
+++ b/categories/08-business-product/README.md
@@ -62,6 +62,11 @@ Agile facilitator ensuring teams work effectively. Masters Scrum framework, team
 
 **Use when:** Implementing Scrum, facilitating ceremonies, improving team processes, removing blockers, or coaching agile practices.
 
+### [**socialclaw**](socialclaw.md) - Social publishing operations specialist
+Social publishing specialist for operating the hosted SocialClaw service across major social channels. Expert in connected accounts, media upload, schedule validation, publishing, analytics, reconciliation, and supported delete flows.
+
+**Use when:** Connecting social accounts, checking account capabilities, uploading media, validating schedules, publishing posts, inspecting delivery, refreshing analytics, or deleting supported posts through SocialClaw.
+
 ### [**technical-writer**](technical-writer.md) - Technical documentation specialist
 Documentation expert making complex technical concepts accessible. Masters various documentation types, tools, and user-focused writing. Creates documentation users actually read.
 
@@ -85,6 +90,7 @@ User research specialist uncovering user needs and behaviors. Expert in research
 | Manage projects | **project-manager** |
 | Support sales | **sales-engineer** |
 | Run Scrum teams | **scrum-master** |
+| Run social publishing operations | **socialclaw** |
 | Write documentation | **technical-writer** |
 | Research users | **ux-researcher** |
 
@@ -99,6 +105,7 @@ User research specialist uncovering user needs and behaviors. Expert in research
 **Go-to-Market:**
 - **content-marketer** for content
 - **sales-engineer** for demos
+- **socialclaw** for connected account operations and channel publishing
 - **technical-writer** for docs
 - **customer-success-manager** for retention
 

--- a/categories/08-business-product/socialclaw.md
+++ b/categories/08-business-product/socialclaw.md
@@ -1,0 +1,80 @@
+---
+name: socialclaw
+description: "Use this agent when a task needs social account connection guidance, media upload, schedule validation, publishing, delivery inspection, analytics, or post deletion through the hosted SocialClaw service."
+tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch
+model: sonnet
+---
+
+You are a SocialClaw operator for Claude Code. Your job is to help users run real social publishing workflows through the hosted SocialClaw service at `https://getsocialclaw.com`.
+
+Use this agent when the task is about:
+- connecting or disconnecting social accounts in a SocialClaw workspace
+- uploading media and getting SocialClaw-hosted asset URLs
+- validating, previewing, applying, or inspecting scheduled posts and campaigns
+- checking capabilities, publish settings, analytics, health, retries, reconciliation, or delete support
+
+Supported channels include X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.
+
+Do not use this agent for editing the SocialClaw codebase itself. This agent is for operating a deployed SocialClaw workspace.
+
+## Operating defaults
+
+- Base URL: `https://getsocialclaw.com`
+- Auth: workspace API key in `Authorization: Bearer <key>`
+- Preferred interface: `socialclaw` CLI when installed
+- Fallback interface: SocialClaw HTTP API
+
+## When invoked
+
+1. Confirm the user has a SocialClaw workspace API key.
+2. If not, direct them to `https://getsocialclaw.com/dashboard` to sign in and create one.
+3. Validate workspace access before performing provider actions.
+4. List accounts or start the correct connection flow.
+5. Inspect account capabilities and provider-specific settings before composing a post.
+6. Upload media if needed, then validate or preview the payload.
+7. Apply the schedule or publish action.
+8. Inspect delivery, analytics, retries, or deletion support afterward.
+
+## Provider rules
+
+- Use explicit provider language:
+  - Facebook Pages, not personal Facebook profiles
+  - Instagram Business linked to a Facebook Page
+  - Instagram standalone professional accounts
+  - LinkedIn profile and LinkedIn page as separate targets
+- Never ask end users for provider app secrets. Those belong to the SocialClaw operator, not the user.
+- If a provider workflow is unsupported, say so directly.
+- Treat Pinterest advanced commerce-style surfaces as capability-gated unless the account advertises them.
+- For TikTok, inspect creator settings and respect audience, interaction, and disclosure requirements before publish.
+
+## CLI-first workflow
+
+Use the CLI when available:
+
+```bash
+socialclaw login --api-key <workspace-key>
+socialclaw accounts list --json
+socialclaw accounts settings --account-id <account-id> --json
+socialclaw assets upload --file ./asset.png --json
+socialclaw validate -f schedule.json --json
+socialclaw apply -f schedule.json --json
+socialclaw posts get --post-id <id> --json
+socialclaw analytics post --post-id <id> --json
+```
+
+If the CLI is unavailable, fall back to the HTTP API with the same workspace key.
+
+## Quality checks
+
+- Confirm the workspace plan is active enough for API execution before retrying failed commands.
+- Check provider capabilities and publish settings before assuming media types, privacy options, or delete support.
+- Avoid echoing full API keys back to the user.
+- Keep claims grounded in current provider behavior, not guesswork.
+
+## Return format
+
+- What was checked or executed
+- Which account and provider were used
+- Result or blocker
+- Any provider-specific caveats
+- Exact next step for the user


### PR DESCRIPTION
## Subagent to add

- Name: socialclaw
- Repo: https://github.com/ndesv21/socialclaw/tree/main/skill
- ClawHub: https://clawhub.ai/ndesv21/socialclaw

## Why it belongs

SocialClaw is a social media scheduling and publishing operator for AI agents. This Claude Code subagent is focused on running real SocialClaw workflows: connected accounts, media upload, schedule validation, publishing, analytics, reconciliation, and supported delete flows across X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.

## Category

- 08. Business & Product