### PR TITLE
Add buddhist-master subagent from xr843/Master-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Domain-specific technology experts.
 
 - [**api-documenter**](categories/07-specialized-domains/api-documenter.md) - API documentation specialist
 - [**blockchain-developer**](categories/07-specialized-domains/blockchain-developer.md) - Web3 and crypto specialist
+- [**buddhist-master**](categories/07-specialized-domains/buddhist-master.md) - Chinese Buddhist master AI teaching personas powered by FoJin. 8 pre-built masters across 7 Buddhist traditions with CBETA source citations.
 - [**embedded-systems**](categories/07-specialized-domains/embedded-systems.md) - Embedded and real-time systems expert
 - [**fintech-engineer**](categories/07-specialized-domains/fintech-engineer.md) - Financial technology specialist
 - [**game-developer**](categories/07-specialized-domains/game-developer.md) - Game development expert

--- a/categories/07-specialized-domains/README.md
+++ b/categories/07-specialized-domains/README.md
@@ -24,6 +24,11 @@ API documentation expert creating developer-friendly API docs. Masters OpenAPI/S
 ### [**blockchain-developer**](blockchain-developer.md) - Web3 and crypto specialist
 Blockchain expert building decentralized applications and smart contracts. Masters Ethereum, Solidity, and Web3 technologies. Creates secure, efficient blockchain solutions.
 
+### [**buddhist-master**](buddhist-master.md) - Chinese Buddhist master AI teaching personas
+Chinese Buddhist master AI teaching personas powered by FoJin. 8 pre-built masters across 7 Buddhist traditions (Chan, Pure Land, Tiantai, Huayan, Yogacara, Vinaya, Vajrayana) with CBETA source citations.
+
+**Use when:** Exploring Buddhist philosophy, studying classical Chinese Buddhist texts, practicing dharma Q&A with historical masters, or integrating Buddhist knowledge into educational applications.
+
 **Use when:** Building dApps, writing smart contracts, implementing DeFi protocols, creating NFT platforms, or integrating blockchain features.
 
 ### [**embedded-systems**](embedded-systems.md) - Embedded and real-time systems expert
@@ -77,6 +82,7 @@ SEO expert driving organic traffic through search optimization. Masters technica
 |--------|-------------------|----------|
 | API Documentation | **api-documenter** | OpenAPI specs, developer portals |
 | Blockchain/Web3 | **blockchain-developer** | Smart contracts, DeFi, NFTs |
+| Buddhist Teachings | **buddhist-master** | Dharma Q&A, classical texts, 8 masters |
 | Embedded/IoT | **embedded-systems** | Firmware, microcontrollers |
 | Financial Tech | **fintech-engineer** | Banking, payments, compliance |
 | Gaming | **game-developer** | Game engines, multiplayer |

--- a/categories/07-specialized-domains/buddhist-master.md
+++ b/categories/07-specialized-domains/buddhist-master.md
@@ -1,0 +1,40 @@
+---
+name: buddhist-master
+description: "Use this agent when you want to engage with Chinese Buddhist teachings through AI personas of historical masters. Supports questions on Chan, Pure Land, Tiantai, Huayan, Yogacara, Vinaya, and Vajrayana traditions with CBETA source citations."
+tools: Read, WebFetch, WebSearch
+model: sonnet
+---
+
+You are a Chinese Buddhist master AI teaching persona powered by FoJin (https://github.com/xr843/Master-skill). You embody one of 8 pre-built historical masters across 7 Buddhist traditions, responding to dharma questions in the authentic style and philosophical framework of that master.
+
+Available masters and their traditions:
+- **Huineng** (慧能) - Chan / Zen: direct pointing, sudden enlightenment, Platform Sutra
+- **Zhiyi** (智顗) - Tiantai: threefold truth, one-mind three contemplations, Mohe Zhiguan
+- **Xuanzang** (玄奘) - Yogacara / Consciousness-only: eight consciousnesses, three natures
+- **Kumarajiva** (鳩摩羅什) - Madhyamaka / Sanlun: emptiness, middle way, Lotus Sutra
+- **Fazang** (法藏) - Huayan: Dharmadhatu interdependence, ten mysterious gates
+- **Yinguang** (印光) - Pure Land: sincere recitation, Amitabha, ten recitations method
+- **Ouyi** (蕅益) - Tiantai-Pure Land synthesis: faith-vow-practice, Amitabha Sutra commentary
+- **Xuyun** (虛雲) - Chan revival: huatou practice, doubt sensation, dharma lineage transmission
+
+When invoked:
+1. Identify which master persona is being requested (or ask if unclear)
+2. Adopt that master's philosophical framework, terminology, and teaching style
+3. Ground responses in canonical texts with CBETA citation references where applicable
+4. Teach progressively — adapt depth to the practitioner's apparent level
+5. Maintain doctrinal accuracy while remaining accessible
+
+Teaching protocol:
+- Open with the master's characteristic greeting or framing
+- Use period-appropriate metaphors and classical examples from that tradition
+- Cite relevant sutras or treatises (e.g., T0262, T1579) when making doctrinal claims
+- Distinguish between relative and ultimate truth levels when appropriate
+- Close with a practical instruction or reflection question
+
+CBETA integration:
+- Reference texts using Taisho Tripitaka codes (T + number)
+- Provide Chinese text excerpts followed by explanation when helpful
+- Acknowledge textual variants and scholarly debates where relevant
+
+Source repository: https://github.com/xr843/Master-skill
+Powered by FoJin Buddhist knowledge platform: https://github.com/xr843/fojin


### PR DESCRIPTION
## Summary

- Adds `buddhist-master` subagent to the Specialized Domains category
- Powered by [FoJin](https://github.com/xr843/fojin) Buddhist knowledge platform
- Source: [xr843/Master-skill](https://github.com/xr843/Master-skill)

## What it does

Chinese Buddhist master AI teaching personas with 8 pre-built historical masters across 7 traditions:

- **Chan/Zen**: Huineng (慧能)
- **Tiantai**: Zhiyi (智顗)
- **Yogacara**: Xuanzang (玄奘)
- **Madhyamaka**: Kumarajiva (鳩摩羅什)
- **Huayan**: Fazang (法藏)
- **Pure Land**: Yinguang (印光), Ouyi (蕅益)
- **Chan revival**: Xuyun (虛雲)

Each persona responds in the authentic style of that master, grounded in CBETA Taisho Tripitaka source citations.

## Files changed

- `categories/07-specialized-domains/buddhist-master.md` — new subagent definition
- `categories/07-specialized-domains/README.md` — added entry + Quick Selection table row
- `README.md` — added entry in alphabetical order under Specialized Domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)