### PR TITLE
Sync qa-sec marketplace version with plugin manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,7 +37,7 @@
       "name": "voltagent-qa-sec",
       "source": "./categories/04-quality-security",
       "description": "Testing, security, and code quality experts - code review, penetration testing, QA automation",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "category": "quality",
       "keywords": ["testing", "security", "code-review", "qa", "penetration-testing", "compliance"]
     },


### PR DESCRIPTION
Update the voltagent-qa-sec entry in .claude-plugin/marketplace.json to match the Quality & Security category plugin version.

This resolves the validate-plugin-versions check by aligning:
- categories/04-quality-security/.claude-plugin/plugin.json
- .claude-plugin/marketplace.json

Both are now set to 1.1.0.