### PR TITLE
Add toprank to Business & Product

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Product management and business analysis.
 - [**technical-writer**](categories/08-business-product/technical-writer.md) - Technical documentation specialist
 - [**ux-researcher**](categories/08-business-product/ux-researcher.md) - User research expert
 - [**wordpress-master**](categories/08-business-product/wordpress-master.md) - WordPress development and optimization expert
+- [**toprank**](https://github.com/nowork-studio/toprank) - SEO and Google Ads plugin for Claude Code. 9 skills across SEO audit, keyword research, content writing, meta tag optimization, schema markup, Google Ads campaign management, and RSA copy generation
 
 ### [09. Meta & Orchestration](categories/09-meta-orchestration/)
 **Plugin:** `voltagent-meta`


### PR DESCRIPTION
Adds toprank under Business & Product, alongside other external plugins already linked in the list (airis-mcp-gateway, taskade, pied-piper).

**What:** A Claude Code plugin (MIT) providing 9 SEO and Google Ads skills. Pulls real Search Console and Google Ads API data, audits traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, and ships fixes. Complements the existing content-marketer and wordpress-master agents in this category.

- Source: https://github.com/nowork-studio/toprank
- License: MIT
- Install: `/plugin marketplace add nowork-studio/toprank`

Note: toprank is a multi-skill plugin rather than a single subagent, but it's linked externally the same way a few other entries in this list are (e.g., airis-mcp-gateway, taskade). Happy to relocate if you'd prefer a different placement.