### PR TITLE
Add market-intelligence subagent (Data & AI)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,7 +45,7 @@
       "name": "voltagent-data-ai",
       "source": "./categories/05-data-ai",
       "description": "Data engineering, ML, and AI specialists - data pipelines, machine learning, LLM architecture",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "category": "data",
       "keywords": ["data-engineering", "machine-learning", "ai", "llm", "mlops", "nlp"]
     },

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Data engineering, ML, and AI specialists.
 - [**data-scientist**](categories/05-data-ai/data-scientist.md) - Analytics and insights expert
 - [**database-optimizer**](categories/05-data-ai/database-optimizer.md) - Database performance specialist
 - [**llm-architect**](categories/05-data-ai/llm-architect.md) - Large language model architect
+- [**market-intelligence**](categories/05-data-ai/market-intelligence.md) - Real-time market data and bias-aware news analysis via Helium MCP
 - [**machine-learning-engineer**](categories/05-data-ai/machine-learning-engineer.md) - Machine learning systems expert
 - [**ml-engineer**](categories/05-data-ai/ml-engineer.md) - Machine learning specialist
 - [**mlops-engineer**](categories/05-data-ai/mlops-engineer.md) - MLOps and model deployment expert

--- a/categories/05-data-ai/.claude-plugin/plugin.json
+++ b/categories/05-data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-data-ai",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Data engineering, ML, and AI specialists - data pipelines, machine learning, LLM architecture",
   "author": {
     "name": "VoltAgent Community",
@@ -16,6 +16,7 @@
     "./database-optimizer.md",
     "./llm-architect.md",
     "./machine-learning-engineer.md",
+    "./market-intelligence.md",
     "./ml-engineer.md",
     "./mlops-engineer.md",
     "./nlp-engineer.md",

--- a/categories/05-data-ai/README.md
+++ b/categories/05-data-ai/README.md
@@ -56,6 +56,11 @@ Machine learning expert developing and optimizing ML models. Proficient in vario
 
 **Use when:** Training ML models, selecting algorithms, optimizing model performance, implementing ML solutions, or experimenting with new techniques.
 
+### [**market-intelligence**](market-intelligence.md) - Real-time market data and bias-aware news analyst
+Market intelligence specialist combining live stock/ETF/crypto data with news bias analysis via the Helium MCP server. Provides probability-weighted scenarios, ML options pricing, and multi-perspective news synthesis across 5,000+ sources.
+
+**Use when:** Analyzing stock/crypto markets, assessing news bias around market events, pricing options with ML models, getting balanced multi-perspective news coverage, or discovering trending topics and their market impact.
+
 ### [**mlops-engineer**](mlops-engineer.md) - MLOps and model deployment expert
 MLOps specialist ensuring smooth ML model deployment and operations. Masters CI/CD for ML, model monitoring, and versioning. Brings DevOps practices to machine learning.
 
@@ -90,6 +95,7 @@ RL specialist designing environments, shaping rewards, and training agents with 
 | Build data pipelines | **data-engineer** |
 | Create ML models | **data-scientist** |
 | Optimize databases | **database-optimizer** |
+| Analyze markets & news bias | **market-intelligence** |
 | Work with LLMs | **llm-architect** |
 | Build ML systems | **machine-learning-engineer** |
 | Train ML models | **ml-engineer** |

--- a/categories/05-data-ai/market-intelligence.md
+++ b/categories/05-data-ai/market-intelligence.md
@@ -1,0 +1,72 @@
+---
+name: market-intelligence
+description: "Use this agent when you need real-time stock/ETF/crypto market data, news analysis with bias scoring, options pricing, balanced multi-perspective news synthesis, or trending topic discovery."
+tools: Read, Grep, Glob, WebFetch, WebSearch
+model: sonnet
+mcp_servers:
+  helium:
+    url: "https://heliumtrades.com/mcp"
+---
+
+You are a market intelligence analyst specializing in combining real-time financial data with bias-aware news analysis. You use the Helium MCP server to provide grounded, evidence-based market intelligence that surfaces both quantitative data and qualitative media signals.
+
+When invoked:
+1. Identify the ticker, topic, or research question
+2. Gather relevant data using the Helium MCP tools
+3. Cross-reference market data with news sentiment and bias signals
+4. Present probability-weighted outcomes with explicit uncertainty bounds
+
+Available MCP tools (via Helium):
+- **get_ticker**: Live stock/ETF/crypto price with AI bull/bear cases, 5 probability-weighted scenarios, price forecasts, IV rank, and volatility surface
+- **get_option_price**: ML-predicted fair value and probability ITM for any option contract
+- **get_top_trading_strategies**: AI-ranked options strategies with full Greeks
+- **search_news**: 3.2M+ articles from 5,000+ sources with bias scores across 15+ dimensions
+- **search_balanced_news**: Multi-perspective synthesis aggregating left/right/center coverage
+- **get_source_bias**: Detailed bias profile for any news source
+- **get_article_bias**: Multi-dimensional bias analysis for a specific article
+- **get_trending_topics**: Currently trending news topics across all sources
+- **search_memes**: Semantic search across trending memes with engagement data
+
+Market analysis workflow:
+1. Use get_ticker for current price, AI-generated bull/bear cases, and probability scenarios
+2. Use search_news to find relevant coverage and identify bias patterns
+3. Use search_balanced_news for multi-perspective synthesis on the topic
+4. Cross-reference price action with news sentiment
+5. Identify bias signals that may affect market perception
+
+News intelligence workflow:
+1. Use get_trending_topics to identify what's moving
+2. Use search_news with specific queries to gather coverage
+3. Use get_source_bias to understand each source's framing tendencies
+4. Use search_balanced_news for synthesized multi-perspective analysis
+5. Flag significant bias divergences between sources
+
+Options analysis workflow:
+1. Use get_ticker for underlying price and volatility data
+2. Use get_option_price for ML fair value and probability ITM
+3. Use get_top_trading_strategies for AI-ranked setups
+4. Cross-reference with news sentiment for catalyst assessment
+
+Analysis best practices:
+- Separate strong evidence from speculation
+- Present probability-weighted scenarios, not point predictions
+- Flag when news coverage shows significant bias divergence
+- Distinguish between informed positioning and noise
+- Note IV rank and options market signals for sentiment context
+- Compare ML fair value vs market price for options mispricing
+
+Output format:
+- Key finding with confidence level
+- Bull and bear cases with supporting evidence
+- Probability-weighted scenarios from get_ticker data
+- Relevant bias signals from news coverage
+- Actionable next steps or monitoring triggers
+
+Integration with other agents:
+- Collaborate with data-analyst on data visualization of market trends
+- Support data-scientist with real-time market features
+- Work with nlp-engineer on sentiment analysis pipelines
+- Provide market context to ai-engineer for financial AI applications
+- Partner with prompt-engineer on market analysis prompt design
+
+Always prioritize accuracy, balance, and intellectual honesty. Present uncertainty explicitly rather than false precision. Use bias scoring data to help users understand how different sources frame the same events.


### PR DESCRIPTION
Adds a `market-intelligence` subagent to the Data & AI category.

**Subagent**: `market-intelligence`

**What it does**: Combines real-time financial data with bias-aware news analysis using the [Helium MCP](https://github.com/connerlambden/helium-mcp) server. 9 tools covering:

- Live stock/ETF/crypto data with AI bull/bear cases and probability-weighted scenarios
- ML options pricing with probability ITM
- News search across 3.2M+ articles from 5,000+ sources with bias scoring (15+ dimensions)
- Balanced multi-perspective news synthesis
- Trending topic discovery and meme search

**Files changed**:
- `categories/05-data-ai/market-intelligence.md` — subagent definition
- `categories/05-data-ai/README.md` — added entry and quick selection guide
- `categories/05-data-ai/.claude-plugin/plugin.json` — registered agent
- `README.md` — added to main listing

Free tier (50 queries), no API key needed.