### PR TITLE
Add cc-agents-md to Meta & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Product management and business analysis.
 Agent coordination and meta-programming.
 
 - [**airis-mcp-gateway**](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%. One command to start, auto-enables servers on demand
+- [**cc-agents-md**](https://github.com/GeiserX/cc-agents-md) - CLI tool and SessionStart hook that discovers and injects AGENTS.md files into Claude Code sessions automatically, with mid-session reload and context compression survival
 - [**agent-installer**](categories/09-meta-orchestration/agent-installer.md) - Browse and install agents from this repository via GitHub
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.md) - Multi-agent coordinator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.md) - Context optimization expert


### PR DESCRIPTION
Adds [cc-agents-md](https://github.com/GeiserX/cc-agents-md) — a CLI tool that loads AGENTS.md files into Claude Code sessions via hooks (SessionStart, UserPromptSubmit, PreCompact). Fits the Meta & Orchestration category alongside other external tools like airis-mcp-gateway and pied-piper.