### PR TITLE
Add idea-factory — multi-subagent startup factory with worktree gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Agent coordination and meta-programming.
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.md) - Multi-agent coordinator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.md) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.md) - Error handling and recovery specialist
+- [**idea-factory**](https://github.com/gguloadoong/idea-factory) - Full virtual startup team via Claude Code subagents. Seven specialized agents (PM / Developer / Designer / Architect / Critic / Code-Reviewer / QA) run an autonomous MVP-First pipeline with a 4-reviewer isolated-worktree gate — anti-leniency pattern that eliminates same-session self-review bias.
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.md) - Knowledge aggregation expert
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration


### PR DESCRIPTION
## Add idea-factory to Meta & Orchestration

**What it is**: [idea-factory](https://github.com/gguloadoong/idea-factory) orchestrates a full virtual startup team via Claude Code subagents. Seven specialized agents (PM / Developer / Designer / Architect / Critic / Code-Reviewer / QA-Tester) collaborate in an autonomous MVP-First pipeline with defined roles and handoffs.

**Why it belongs here**: The subagent pattern is central — every gate review runs Architect, Critic, Code-Reviewer, and QA-Tester in isolated worktrees with fresh context, explicitly preventing same-session self-review bias (Evaluator Leniency). This is an advanced multi-subagent orchestration pattern well-suited to the Meta & Orchestration category.

**Repo**: https://github.com/gguloadoong/idea-factory
**License**: MIT