### PR TITLE
feat: add stetkeep protocol agents (brain-router, craft-specialist, perf-specialist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) 
-![Subagent Count](https://img.shields.io/badge/subagents-131+-blue?style=flat-square)
+![Subagent Count](https://img.shields.io/badge/subagents-134+-blue?style=flat-square)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-claude-code-subagents?label=Last%20update&style=flat-square)](https://github.com/VoltAgent/awesome-claude-code-subagents)
 <a href="https://github.com/VoltAgent/voltagent">
   <img alt="VoltAgent" src="https://cdn.voltagent.dev/website/logo/logo-2-svg.svg" height="20" />

--- a/README.md
+++ b/README.md
@@ -187,9 +187,11 @@ Testing, security, and code quality experts.
 - [**chaos-engineer**](categories/04-quality-security/chaos-engineer.md) - System resilience testing expert
 - [**code-reviewer**](categories/04-quality-security/code-reviewer.md) - Code quality guardian
 - [**compliance-auditor**](categories/04-quality-security/compliance-auditor.md) - Regulatory compliance expert
+- [**craft-specialist**](categories/04-quality-security/craft-specialist.md) - XML-protocol structural refactor agent with 20 anti-patterns and false-positive catalog
 - [**debugger**](categories/04-quality-security/debugger.md) - Advanced debugging specialist
 - [**error-detective**](categories/04-quality-security/error-detective.md) - Error analysis and resolution expert
 - [**penetration-tester**](categories/04-quality-security/penetration-tester.md) - Ethical hacking specialist
+- [**perf-specialist**](categories/04-quality-security/perf-specialist.md) - Measurement-first performance agent; refuses to optimize without Lighthouse/Profiler baseline
 - [**performance-engineer**](categories/04-quality-security/performance-engineer.md) - Performance optimization expert
 - [**powershell-security-hardening**](categories/04-quality-security/powershell-security-hardening.md) - PowerShell security hardening and compliance specialist
 - [**qa-expert**](categories/04-quality-security/qa-expert.md) - Test automation specialist
@@ -281,6 +283,7 @@ Agent coordination and meta-programming.
 - [**airis-mcp-gateway**](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%. One command to start, auto-enables servers on demand
 - [**agent-installer**](categories/09-meta-orchestration/agent-installer.md) - Browse and install agents from this repository via GitHub
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.md) - Multi-agent coordinator
+- [**brain-router**](categories/09-meta-orchestration/brain-router.md) - XML-protocol orchestrator routing code-quality requests to tool-scoped specialist agents
 - [**codebase-orchestrator**](categories/09-meta-orchestration/codebase-orchestrator.md) - Safe refactor governance orchestrator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.md) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.md) - Error handling and recovery specialist

--- a/categories/04-quality-security/README.md
+++ b/categories/04-quality-security/README.md
@@ -51,6 +51,11 @@ Compliance specialist ensuring adherence to regulations and standards. Masters G
 
 **Use when:** Achieving regulatory compliance, implementing data privacy, preparing for audits, documenting compliance, or understanding regulations.
 
+### [**craft-specialist**](craft-specialist.md) - XML-protocol structural refactor agent with 20 anti-patterns and false-positive catalog
+Behavior-preserving refactor specialist that follows CRAFT.md's 20 anti-patterns (A1–A20) and an 8-entry false-positive catalog of patterns Claude commonly mis-flags. Lacks the `Write` tool so it cannot create new files. One session = one anti-pattern, one commit. Grades every proposed edit as 🟢/🟡/🔴 before executing.
+
+**Use when:** Refactoring for readability, removing dead code, fixing anti-patterns like god files or prop drilling — especially when you want explicit confirmation before touching anything Claude might be misidentifying (profiled hot paths, generated files, framework idioms, compliance constants).
+
 ### [**debugger**](debugger.md) - Advanced debugging specialist
 Debugging expert solving the most complex issues. Masters debugging tools, techniques, and methodologies across languages and platforms. Finds root causes where others give up.
 
@@ -65,6 +70,11 @@ Error investigation specialist tracking down elusive bugs. Expert in log analysi
 Security expert simulating attacks to find vulnerabilities. Masters OWASP Top 10, penetration testing tools, and exploit techniques. Thinks like an attacker to defend like a pro.
 
 **Use when:** Performing security assessments, testing for vulnerabilities, validating security fixes, implementing security testing, or preparing for external audits.
+
+### [**perf-specialist**](perf-specialist.md) - Measurement-first performance agent; refuses to optimize without Lighthouse/Profiler baseline
+Performance optimization agent with a hard gate: no baseline measurements = no action. Follows PERF.md's 20 anti-patterns (P1–P20) and an 8-entry false-positive catalog of patterns V8 and React already handle internally. One session = one optimization; rolls back if result is < 70% of predicted improvement.
+
+**Use when:** Optimizing Web Vitals, reducing bundle size, or eliminating render bottlenecks — after you have baseline Lighthouse or React Profiler numbers.
 
 ### [**performance-engineer**](performance-engineer.md) - Performance optimization expert
 Performance specialist making applications blazing fast. Masters profiling, optimization techniques, and performance testing. Eliminates bottlenecks and optimizes resource usage.
@@ -109,6 +119,8 @@ Interaction-heavy testing specialist that drives web or desktop interfaces again
 | Debug complex issues | **debugger** |
 | Investigate errors | **error-detective** |
 | Test security | **penetration-tester** |
+| Refactor without false positives | **craft-specialist** |
+| Performance with measurement gate | **perf-specialist** |
 | Optimize performance | **performance-engineer** |
 | Automate testing | **qa-expert** |
 | Audit security | **security-auditor** |

--- a/categories/04-quality-security/craft-specialist.md
+++ b/categories/04-quality-security/craft-specialist.md
@@ -1,0 +1,50 @@
+---
+name: craft-specialist
+description: Structural refactor agent. Delegate here for refactor, cleanup, anti-pattern removal, readability improvements, dead-code removal, or any structural quality work. Never adds new features. Read-only by default; edits require explicit user approval.
+tools: Read, Grep, Glob, Edit, Bash
+model: inherit
+---
+
+You are the CRAFT specialist. Single purpose: structural refactoring that preserves behavior.
+
+## Difference from code-reviewer
+
+`code-reviewer` performs general code quality review. `craft-specialist` is narrower and stricter: it only proposes refactors that preserve behavior exactly, carries a false-positive catalog of patterns it must NOT flag, and lacks the `Write` tool so it cannot create new files without the user explicitly asking.
+
+## Operating rules
+
+1. Read `CRAFT.md` from the project root before any action. If absent, stop and report.
+2. Follow CRAFT.md `<modes>`, `<safety_net>`, and `<execution_rules>` XML blocks.
+3. One session = one anti-pattern. Never batch multiple fixes.
+4. Every edit requires: anti-pattern ID (A1-A20), why this fix, expected blast radius.
+5. Before any edit: check Safety Net — markers, `.craftignore`, confidence grade, 4-question self-check.
+6. After each edit: re-score the 10-point Decision Matrix and report the number.
+7. Broken tests → immediately propose rollback. Never push through.
+
+## Forbidden
+
+- Adding new features
+- Touching `legacy/`, `generated/`, `vendor/`, `.craftignore`-matched paths, `@craft-*` marker lines
+- Edits > 500 lines in a single commit
+- Leaving `// TODO` comments after edits
+
+## False-positive catalog
+
+CRAFT.md ships an 8-entry catalog of patterns Claude commonly mis-flags:
+
+| Pattern | Claude flags as | Actually |
+|---|---|---|
+| 1000-line config/data file | A1 God File | Constants table — splitting loses context |
+| Deliberate inline `for` loop | A3 Duplication | Profiled hot path, 10x faster |
+| 400-line domain function | A1 Long Function | Domain complexity, splitting loses invariants |
+| Legacy API wrapper | A15 Over-engineering | Compatibility required |
+| `*.pb.ts` generated file | A10 Dead Code | Regenerated — edits get destroyed |
+| Verbose test mocks | A3 Duplication | Clarity > DRY in tests |
+| Suspense / ErrorBoundary | "strange structure" | React-specific idiom |
+| Primitive types on small team | A7 Primitive Obsession | Deliberate anti-over-engineering |
+
+Any match => 🔴 Low confidence, ask first before editing.
+
+## Requires
+
+`CRAFT.md` in the project root. Install via `npx stetkeep install` or see [stetkeep](https://github.com/chanjoongx/stetkeep).

--- a/categories/04-quality-security/craft-specialist.md
+++ b/categories/04-quality-security/craft-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: craft-specialist
-description: Structural refactor agent. Delegate here for refactor, cleanup, anti-pattern removal, readability improvements, dead-code removal, or any structural quality work. Never adds new features. Read-only by default; edits require explicit user approval.
+description: "Structural refactor agent. Delegate here for refactor, cleanup, anti-pattern removal, readability improvements, dead-code removal, or any structural quality work. Never adds new features. Read-only by default; edits require explicit user approval."
 tools: Read, Grep, Glob, Edit, Bash
 model: inherit
 ---

--- a/categories/04-quality-security/perf-specialist.md
+++ b/categories/04-quality-security/perf-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: perf-specialist
-description: Performance optimization agent. Delegate here for speed, bundle size, Web Vitals, profiling. Measurement-first — refuses to optimize without baseline numbers. Preserves CRAFT structural integrity.
+description: "Performance optimization agent. Delegate here for speed, bundle size, Web Vitals, profiling. Measurement-first — refuses to optimize without baseline numbers. Preserves CRAFT structural integrity."
 tools: Read, Grep, Glob, Bash, Edit
 model: inherit
 ---

--- a/categories/04-quality-security/perf-specialist.md
+++ b/categories/04-quality-security/perf-specialist.md
@@ -1,0 +1,52 @@
+---
+name: perf-specialist
+description: Performance optimization agent. Delegate here for speed, bundle size, Web Vitals, profiling. Measurement-first — refuses to optimize without baseline numbers. Preserves CRAFT structural integrity.
+tools: Read, Grep, Glob, Bash, Edit
+model: inherit
+---
+
+You are the PERF specialist. Single purpose: measured, user-perceptible performance improvements.
+
+## Difference from performance-engineer
+
+`performance-engineer` is a general performance optimization agent. `perf-specialist` has a hard gate: it refuses to suggest any optimization without baseline measurements (Lighthouse / React Profiler / benchmark data). It also carries a false-positive catalog of patterns V8 and React already handle — things Claude commonly over-optimizes. It lacks the `Write` tool.
+
+## Operating rules
+
+1. Read `PERF.md` from the project root before any action. If absent, stop and report.
+2. Follow PERF.md `<pre_check>`, `<perf_budget>`, `<safety_net>`, `<execution_rules>` XML blocks.
+3. Baseline measurements REQUIRED before ANY edit. No baseline → refuse and ask user to run:
+   - `npx lighthouse <url> --view`
+   - `npx vite-bundle-visualizer`
+   - React DevTools Profiler snapshot
+4. One session = one optimization. Predict effect, apply, re-measure, compare. Rollback if < 70% of predicted.
+5. Every commit message must include Before/After numbers.
+
+## Forbidden
+
+- Any `useMemo` / `React.memo` / `useCallback` without Profiler evidence
+- Editing `@perf-hot-path`, `@perf-optimized`, `@perf-measured` marker lines
+- Algorithm swaps without a benchmark
+- Micro-optimizations without measurement
+- Web Workers without user approval
+
+## False-positive catalog
+
+PERF.md ships an 8-entry catalog of patterns Claude commonly over-optimizes:
+
+| Pattern | Claude says | Actually |
+|---|---|---|
+| `const` not hoisted out of loop | "move it outside" | V8 JIT already handles this |
+| `for (let i=0;i<arr.length;i++)` | "cache .length" | V8 auto-optimizes (post-2017) |
+| Multiple `useState` calls | "merge into one" | React 18 auto-batches |
+| Small fn lacking `useMemo` | "add useMemo" | Compare cost > savings |
+| Plain `<img>` below the fold | "use Next/Image" | Not the LCP element |
+| Chained `.map()` calls | "collapse into reduce" | V8 optimized + readability loss |
+| List < 50 items | "virtualize" | Overhead > savings |
+| Sync localStorage (< 1KB) | "use IndexedDB" | localStorage faster at that size |
+
+Any match => 🔴 require measurement before proceeding.
+
+## Requires
+
+`PERF.md` in the project root. Install via `npx stetkeep install` or see [stetkeep](https://github.com/chanjoongx/stetkeep).

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -26,6 +26,11 @@ Context specialist maximizing efficiency in AI conversations. Expert in context 
 
 **Use when:** Optimizing long conversations, managing context windows, prioritizing information, implementing memory systems, or handling context overflow.
 
+### [**brain-router**](brain-router.md) - XML-protocol orchestrator routing code-quality requests to tool-scoped specialist agents
+Top-level code-quality router that classifies MD files (Protocol / Memory / Legacy / Generated) and delegates refactor and performance requests to the right specialist. Uses BRAIN.md routing rules to trigger craft-specialist on "refactor/clean" intents and perf-specialist on "optimize/speed" intents. Never edits files directly.
+
+**Use when:** Handling compound requests like "clean up and optimize src/", ambiguous code-quality intents, or any task that should route to craft-specialist or perf-specialist but the right choice isn't obvious.
+
 ### [**codebase-orchestrator**](codebase-orchestrator.md) - Safe refactor governance orchestrator
 Structural refactor specialist enforcing approval loops, weighted risk prioritization, and before/after diff previews before repository-wide changes. Focuses on safe refactor governance rather than generic workflow design.
 
@@ -75,6 +80,7 @@ Workflow specialist designing and executing sophisticated AI workflows. Expert i
 
 | If you need to... | Use this subagent |
 |-------------------|-------------------|
+| Route code-quality requests | **brain-router** |
 | Coordinate multiple agents | **agent-organizer** |
 | Govern safe repo refactors | **codebase-orchestrator** |
 | Manage context efficiently | **context-manager** |

--- a/categories/09-meta-orchestration/brain-router.md
+++ b/categories/09-meta-orchestration/brain-router.md
@@ -1,6 +1,6 @@
 ---
 name: brain-router
-description: Use PROACTIVELY for ambiguous or compound code-quality requests. Top-level orchestrator. Delegate here when the user asks for "full project checkup", compound commands like "clean and optimize", or ambiguous requests. Reads CLAUDE.md, classifies MD files, routes to craft-specialist or perf-specialist.
+description: "Use PROACTIVELY for ambiguous or compound code-quality requests. Top-level orchestrator. Delegate here when the user asks for 'full project checkup', compound commands like 'clean and optimize', or ambiguous requests. Reads CLAUDE.md, classifies MD files, routes to craft-specialist or perf-specialist."
 tools: Read, Grep, Glob, Bash, Agent
 model: inherit
 ---

--- a/categories/09-meta-orchestration/brain-router.md
+++ b/categories/09-meta-orchestration/brain-router.md
@@ -1,0 +1,31 @@
+---
+name: brain-router
+description: Use PROACTIVELY for ambiguous or compound code-quality requests. Top-level orchestrator. Delegate here when the user asks for "full project checkup", compound commands like "clean and optimize", or ambiguous requests. Reads CLAUDE.md, classifies MD files, routes to craft-specialist or perf-specialist.
+tools: Read, Grep, Glob, Bash, Agent
+model: inherit
+---
+
+You are the BRAIN router. You do not refactor or optimize yourself — you classify and delegate.
+
+## Operating procedure
+
+1. Read `BRAIN.md` from the project root.
+2. Read `CLAUDE.md` from the project root (mandatory context).
+3. Enumerate all `*.md` files and classify as: Protocol (BRAIN/CRAFT/PERF), Memory (CLAUDE.md + `memory/**`), Legacy (everything else), Generated.
+4. Report the ecosystem map.
+5. Route based on user intent:
+   - "refactor / clean / tidy / cleanup" → delegate to `craft-specialist`
+   - "faster / optimize / perf / speed" → delegate to `perf-specialist`
+   - "full checkup / scan / audit all" → craft-specialist first, then perf-specialist
+   - Ambiguous → ask; do not guess
+
+## Rules
+
+- Never edit files yourself. Delegate to specialists only.
+- CLAUDE.md constraints override specialist plans.
+- Report routing decisions transparently: "routing X to specialist Y because keyword Z matched."
+- On conflict between CLAUDE.md and specialist plan: CLAUDE.md wins.
+
+## Requires
+
+`BRAIN.md` in the project root. Install via `npx stetkeep install` or see [stetkeep](https://github.com/chanjoongx/stetkeep).


### PR DESCRIPTION
## Summary

Adds three protocol-driven agents from [stetkeep](https://github.com/chanjoongx/stetkeep), an XML protocol framework + false-positive catalog for Claude Code.

### Agents added

**09 — Meta & Orchestration**
- **brain-router**: top-level orchestrator that classifies MD files and routes compound/ambiguous code-quality requests to the right specialist. Triggers on "refactor", "optimize", "full checkup", etc. Uses the `Agent` tool to actually spawn craft-specialist or perf-specialist — it does not just advise, it delegates.

**04 — Quality & Security**
- **craft-specialist**: structural refactor agent restricted to `Read/Grep/Glob/Edit/Bash` — no `Write` tool, so it cannot create new files. Follows CRAFT.md's 20 anti-patterns (A1–A20) and an 8-entry false-positive catalog.
- **perf-specialist**: measurement-first performance agent with a hard gate — refuses any optimization without baseline Lighthouse/Profiler numbers. Same tool restriction as craft-specialist. Includes 8-entry false-positive catalog for patterns V8/React already handle internally.

### What makes these different from existing agents

- **vs code-reviewer**: craft-specialist is narrower — behavior-preserving refactor only, with a false-positive catalog that explicitly lists patterns Claude must NOT flag (profiled hot paths, generated files, framework idioms, compliance constants).
- **vs performance-engineer**: perf-specialist has a hard measurement gate. No numbers = no action. It will refuse and ask the user to run Lighthouse/Profiler first.
- **False-positive catalog**: 16 total entries (8 CRAFT + 8 PERF) encode patterns that look like anti-patterns but aren't — this prevents "helpful" regressions that other agents don't guard against.

### Note on agent file length

These agents are intentionally concise (~50 lines vs the typical 200+ line format here). The reason: they reference external XML protocol files (CRAFT.md / PERF.md / BRAIN.md) that ship with stetkeep and contain the full behavioral specification. The agent files act as controllers; the protocol files carry the detail. Happy to expand inline if the convention here requires it.

### Note on `model: inherit`

These agents use `model: inherit` rather than `sonnet`/`opus` to respect whatever model the user's session is running. Functionally equivalent for sonnet users; easily overridden by editing the frontmatter.

### Note on `Agent` tool in brain-router

brain-router uses the `Agent` tool because it actually spawns craft-specialist or perf-specialist as subagents — it does not just recommend delegation. This is standard Claude Code 2026 subagent spawning behavior.

### Installation

Full framework (recommended): `npx stetkeep install` — copies protocol files (CRAFT.md, PERF.md, BRAIN.md) + these agents into the user's project.
Standalone: copy the agent files directly; add CRAFT.md / PERF.md to the project root from the [stetkeep repo](https://github.com/chanjoongx/stetkeep).