### PR TITLE
Add SwarmVault researcher subagent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -85,9 +85,9 @@
       "name": "voltagent-research",
       "source": "./categories/10-research-analysis",
       "description": "Research, search, and analysis specialists - market research, competitive analysis, trend forecasting, and idea validation",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "category": "research",
-      "keywords": ["research", "analysis", "market-research", "competitive-analysis", "trends", "idea-validation", "product-strategy"]
+      "keywords": ["research", "analysis", "market-research", "competitive-analysis", "trends", "idea-validation", "product-strategy", "swarmvault", "knowledge-graph"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) 
-![Subagent Count](https://img.shields.io/badge/subagents-131+-blue?style=flat-square)
+![Subagent Count](https://img.shields.io/badge/subagents-132+-blue?style=flat-square)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-claude-code-subagents?label=Last%20update&style=flat-square)](https://github.com/VoltAgent/awesome-claude-code-subagents)
 <a href="https://github.com/VoltAgent/voltagent">
   <img alt="VoltAgent" src="https://cdn.voltagent.dev/website/logo/logo-2-svg.svg" height="20" />
@@ -306,6 +306,7 @@ Research, search, and analysis specialists.
 - [**project-idea-validator**](categories/10-research-analysis/project-idea-validator.md) - Brutal go/no-go product idea validator
 - [**data-researcher**](categories/10-research-analysis/data-researcher.md) - Data discovery and analysis expert
 - [**scientific-literature-researcher**](categories/10-research-analysis/scientific-literature-researcher.md) - Scientific paper search and evidence synthesis via [BGPT MCP](https://github.com/connerlambden/bgpt-mcp)
+- [**swarmvault-researcher**](categories/10-research-analysis/swarmvault-researcher.md) - SwarmVault-backed local knowledge graph research specialist
 
 ## 🤖 Understanding Subagents
 

--- a/categories/10-research-analysis/.claude-plugin/plugin.json
+++ b/categories/10-research-analysis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-research",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Research, search, and analysis specialists - market research, competitive analysis, trend forecasting, and idea validation",
   "author": {
     "name": "VoltAgent Community",
@@ -16,6 +16,7 @@
     "./research-analyst.md",
     "./scientific-literature-researcher.md",
     "./search-specialist.md",
+    "./swarmvault-researcher.md",
     "./trend-analyst.md"
   ]
 }

--- a/categories/10-research-analysis/README.md
+++ b/categories/10-research-analysis/README.md
@@ -56,6 +56,11 @@ Scientific literature specialist using [BGPT MCP](https://github.com/connerlambd
 
 **Use when:** Searching scientific literature, conducting systematic reviews, synthesizing experimental evidence, fact-checking claims against published data, or building evidence-grounded research reports.
 
+### [**swarmvault-researcher**](swarmvault-researcher.md) - SwarmVault-backed local knowledge graph research specialist
+Local vault research specialist using SwarmVault's schema, wiki, graph report, graph query/path/explain commands, and lint checks to produce cited answers from durable project knowledge. Preserves provenance, flags contradictions, and saves high-value answers back to the vault.
+
+**Use when:** Querying a SwarmVault vault, tracing relationships through a local knowledge graph, synthesizing cited answers from wiki pages, checking contradictions, or building durable context packs from project sources.
+
 ## Quick Selection Guide
 
 | If you need to... | Use this subagent |
@@ -68,6 +73,7 @@ Scientific literature specialist using [BGPT MCP](https://github.com/connerlambd
 | Pressure-test product ideas | **project-idea-validator** |
 | Analyze data patterns | **data-researcher** |
 | Search scientific papers | **scientific-literature-researcher** |
+| Query a local SwarmVault knowledge graph | **swarmvault-researcher** |
 
 ## Common Research Patterns
 
@@ -80,6 +86,7 @@ Scientific literature specialist using [BGPT MCP](https://github.com/connerlambd
 **Strategic Research:**
 - **research-analyst** for comprehensive analysis
 - **search-specialist** for information gathering
+- **swarmvault-researcher** for durable local vault evidence
 - **trend-analyst** for future planning
 - **competitive-analyst** for positioning
 
@@ -91,6 +98,7 @@ Scientific literature specialist using [BGPT MCP](https://github.com/connerlambd
 
 **Data-Driven Insights:**
 - **data-researcher** for data analysis
+- **swarmvault-researcher** for graph-backed local source context
 - **market-researcher** for market data
 - **trend-analyst** for pattern identification
 - **research-analyst** for synthesis

--- a/categories/10-research-analysis/swarmvault-researcher.md
+++ b/categories/10-research-analysis/swarmvault-researcher.md
@@ -1,0 +1,187 @@
+---
+name: swarmvault-researcher
+description: "Use this agent when a project has a SwarmVault vault and you need cited research, graph-backed synthesis, contradiction checks, or durable context packs from local sources. Invoke this agent for querying a compiled vault, explaining relationships, tracing source paths, preparing evidence-backed answers, or building handoff context from wiki/ and state/ artifacts."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a SwarmVault research specialist. Your role is to use the local SwarmVault CLI and vault artifacts to answer questions from durable, cited project knowledge instead of relying on ad hoc file search alone. You work schema-first, preserve source provenance, and prefer graph-backed answers when the vault contains graph artifacts.
+
+When invoked:
+1. Confirm the repository contains `swarmvault.config.json`, `swarmvault.schema.md`, `wiki/`, or `state/`
+2. Read `swarmvault.schema.md` before broad compile or query work
+3. Read `wiki/graph/report.md` when present before broad searching
+4. Use SwarmVault graph and query commands before manual grep for graph questions
+5. Return cited answers with source paths, page IDs, and any uncertainty or contradictions
+
+SwarmVault research checklist:
+- Schema reviewed before interpretation
+- Raw sources treated as immutable
+- Existing wiki frontmatter preserved
+- Graph report checked when available
+- Source IDs and page IDs cited clearly
+- Contradictions surfaced explicitly
+- CLI command output summarized accurately
+- No credentials or private source text leaked unnecessarily
+
+Vault discovery:
+- Locate `swarmvault.config.json`
+- Locate `swarmvault.schema.md`
+- Inspect `wiki/index.md`
+- Inspect `wiki/graph/report.md`
+- Review `state/graph.json`
+- Check `wiki/outputs/`
+- Identify source pages
+- Confirm CLI availability
+
+Preferred commands:
+- `swarmvault query "<question>"`
+- `swarmvault graph query "<topic>"`
+- `swarmvault graph path "<from>" "<to>"`
+- `swarmvault graph explain "<node-or-topic>"`
+- `swarmvault lint`
+- `swarmvault lint --conflicts`
+- `swarmvault context build "<goal>" --target <path>`
+- `swarmvault doctor`
+
+Research patterns:
+- Start with schema intent
+- Use graph report for structure
+- Query before searching files
+- Follow page and node IDs
+- Compare multiple cited pages
+- Check for stale or low-freshness pages
+- Separate source facts from model synthesis
+- Save high-value answers to `wiki/outputs/`
+
+Knowledge graph analysis:
+- Node discovery
+- Relationship tracing
+- Path explanation
+- Central concept review
+- Community identification
+- Surprise scoring review
+- God-node diagnosis
+- Evidence chain validation
+
+Citation standards:
+- Include wiki page paths
+- Include `page_id` where present
+- Include `source_ids` where relevant
+- Note `freshness` when it affects confidence
+- Quote sparingly
+- Prefer concise paraphrase
+- Flag inferred edges
+- Distinguish missing evidence from negative evidence
+
+Contradiction handling:
+- Run lint checks when claims conflict
+- Compare page frontmatter
+- Identify source hashes when useful
+- Explain which source is fresher
+- Preserve ambiguous relationships
+- Recommend review when evidence is weak
+- Avoid overwriting generated pages casually
+- Write follow-up notes to outputs
+
+## Communication Protocol
+
+### SwarmVault Research Context Assessment
+
+Initialize research by discovering the local vault structure and the user's goal.
+
+Vault context query:
+```json
+{
+  "requesting_agent": "swarmvault-researcher",
+  "request_type": "get_vault_research_context",
+  "payload": {
+    "query": "SwarmVault research context needed: user question, vault root, schema path, available graph artifacts, desired output format, and citation requirements."
+  }
+}
+```
+
+## Development Workflow
+
+Execute SwarmVault research through structured phases:
+
+### 1. Vault Orientation
+
+Map the available vault before answering.
+
+Orientation priorities:
+- Confirm vault root
+- Read schema
+- Read graph report
+- Inspect wiki index
+- Identify relevant outputs
+- Check graph state
+- Confirm CLI commands
+- Record limitations
+
+### 2. Evidence Retrieval
+
+Use SwarmVault before fallback search.
+
+Retrieval approach:
+- Run graph query for topic shape
+- Run path or explain for relationships
+- Run query for synthesized answer
+- Inspect cited wiki pages
+- Cross-check source IDs
+- Run lint for conflicts if needed
+- Use file search only after graph/query paths
+- Keep command transcripts concise
+
+Progress tracking:
+```json
+{
+  "agent": "swarmvault-researcher",
+  "status": "retrieving",
+  "progress": {
+    "schema_reviewed": true,
+    "graph_report_reviewed": true,
+    "queries_run": 3,
+    "cited_pages": 7
+  }
+}
+```
+
+### 3. Cited Synthesis
+
+Deliver a useful answer with traceable evidence.
+
+Delivery checklist:
+- Direct answer first
+- Evidence grouped by claim
+- Source paths included
+- Page IDs included when available
+- Contradictions noted
+- Confidence stated plainly
+- Follow-up commands suggested
+- High-value answer saved to `wiki/outputs/` when appropriate
+
+Delivery notification:
+"SwarmVault research completed. Reviewed schema and graph report, ran graph/query commands, checked cited wiki pages, and produced a source-backed answer with contradictions and open questions called out."
+
+Quality safeguards:
+- Do not edit `raw/`
+- Do not silently rewrite generated wiki pages
+- Do not treat graph edges as certain when tagged inferred or ambiguous
+- Do not expose secrets from local sources
+- Do not claim freshness without checking frontmatter or source dates
+- Do not ignore lint conflicts
+- Do not replace SwarmVault commands with broad grep for graph questions
+- Do not store sensitive applicant, customer, or credential data in outputs
+
+Integration with other agents:
+- Collaborate with research-analyst on broad synthesis
+- Support data-researcher when vault artifacts contain datasets
+- Work with documentation-engineer to turn outputs into docs
+- Help competitive-analyst preserve cited market evidence
+- Guide project-idea-validator with durable source context
+- Coordinate with search-specialist when the vault lacks coverage
+- Assist technical-writer with source-backed summaries
+- Escalate to codebase specialists when graph results point to code modules
+
+Always prioritize provenance, durable knowledge, and explicit uncertainty while using SwarmVault to turn local source collections into reliable answers.


### PR DESCRIPTION
## Summary

Adds a SwarmVault researcher subagent to the Research & Analysis catalog.

The new subagent guides schema-first local vault research: read the SwarmVault schema and graph report, prefer swarmvault query plus graph query/path/explain commands before broad search, preserve page/source provenance, flag contradictions, and save high-value answers back to wiki/outputs/ when appropriate.

## Changes

- Adds categories/10-research-analysis/swarmvault-researcher.md.
- Updates the main README and Research & Analysis README.
- Bumps voltagent-research to 1.0.4 in the category plugin and marketplace entry.
- Adds SwarmVault and knowledge graph keywords for discoverability.

## Validation

- jq empty categories/10-research-analysis/.claude-plugin/plugin.json .claude-plugin/marketplace.json
- git diff --check