### PR TITLE
Add claude-code-dual-build to Meta & Orchestration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
       "name": "voltagent-meta",
       "source": "./categories/09-meta-orchestration",
       "description": "Agent coordination and meta-programming - multi-agent orchestration, workflow automation, and safe refactor governance. Works best with other voltagent plugins installed.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "category": "orchestration",
       "keywords": ["multi-agent", "orchestration", "workflow", "coordination", "meta", "refactor", "codebase-governance"]
     },

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Agent coordination and meta-programming.
 - [**airis-mcp-gateway**](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%. One command to start, auto-enables servers on demand
 - [**agent-installer**](categories/09-meta-orchestration/agent-installer.md) - Browse and install agents from this repository via GitHub
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.md) - Multi-agent coordinator
+- [**claude-code-dual-build**](https://github.com/cjcsecurity/claude-code-dual-build) - Symmetric multi-agent build with bidirectional cross-review for Claude Code + Codex; bundles claude-builder, codex-builder, claude-reviewer, codex-reviewer
 - [**codebase-orchestrator**](categories/09-meta-orchestration/codebase-orchestrator.md) - Safe refactor governance orchestrator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.md) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.md) - Error handling and recovery specialist

--- a/categories/09-meta-orchestration/.claude-plugin/plugin.json
+++ b/categories/09-meta-orchestration/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-meta",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Agent coordination and meta-programming - multi-agent orchestration, workflow automation, and safe refactor governance. Works best with other voltagent plugins installed.",
   "author": {
     "name": "VoltAgent Community",

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -21,6 +21,11 @@ Orchestration expert managing complex multi-agent collaborations. Masters task d
 
 **Use when:** Coordinating multiple agents, breaking down complex tasks, managing agent dependencies, synthesizing results, or designing agent workflows.
 
+### [**claude-code-dual-build**](https://github.com/cjcsecurity/claude-code-dual-build) - Symmetric multi-agent build with bidirectional cross-review
+Cross-review orchestration skill that splits a coding task ~50/50 between Claude and Codex, runs both in parallel in isolated git worktrees, then has the opposite model review each diff before consolidation. Bundles four custom subagents — claude-builder, codex-builder, claude-reviewer, codex-reviewer — coordinated by a `/dual-build` skill. Lightweight (~700 lines of markdown, no framework, no MCP server).
+
+**Use when:** Multi-component features with clean module boundaries, batch fixes across 3+ unrelated files, refactors with parallel slices, or audit-and-fix passes where you want a different model family's eyes on each diff.
+
 ### [**context-manager**](context-manager.md) - Context optimization expert
 Context specialist maximizing efficiency in AI conversations. Expert in context windows, information prioritization, and memory management. Ensures optimal use of limited context space.
 
@@ -76,6 +81,7 @@ Workflow specialist designing and executing sophisticated AI workflows. Expert i
 | If you need to... | Use this subagent |
 |-------------------|-------------------|
 | Coordinate multiple agents | **agent-organizer** |
+| Cross-review parallel Claude+Codex builds | **[claude-code-dual-build](https://github.com/cjcsecurity/claude-code-dual-build)** |
 | Govern safe repo refactors | **codebase-orchestrator** |
 | Manage context efficiently | **context-manager** |
 | Handle system errors | **error-coordinator** |


### PR DESCRIPTION
Adding `claude-code-dual-build` to **09. Meta & Orchestration** as an external-link entry (same pattern as `airis-mcp-gateway`, `pied-piper`, `taskade`).

It's a Claude Code skill (`/dual-build`) that orchestrates symmetric Claude+Codex builds with mandatory bidirectional cross-review, packaged with four custom subagents:

- `claude-builder` / `codex-builder` — implement subtasks in parallel git worktrees
- `claude-reviewer` / `codex-reviewer` — fresh-eyes cross-review of the *opposite* model's diff

The cross-review is the load-bearing piece — different model families catch different bug classes. On a real `mission-control` run, Claude reviewing Codex's stop-button code caught a SIGKILL→ESRCH race + an `ss` permission-model UX bug that the implementing model missed (worked example in [EXAMPLES.md](https://github.com/cjcsecurity/claude-code-dual-build/blob/main/EXAMPLES.md)).

Per CONTRIBUTING.md's required-files rule, this PR updates:
- Main `README.md` — adds the listing entry alphabetically (between `agent-organizer` and `codebase-orchestrator`)
- `categories/09-meta-orchestration/README.md` — adds the description block in *Available Subagents* and a row in *Quick Selection Guide*

Repo: https://github.com/cjcsecurity/claude-code-dual-build