### PR TITLE
Add agent-lsp to Development Experience tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Data engineering, ML, and AI specialists.
 
 Tooling and developer productivity experts.
 
+- [**agent-lsp**](https://github.com/blackwell-systems/agent-lsp) - LSP-powered code intelligence for 30 languages with 66 tools (go-to-definition, find-references, call-hierarchy, blast-radius analysis) and 24 multi-step workflow skills (refactor, rename, impact analysis). Enables agents to understand code structure without grep/sed.
 - [**build-engineer**](categories/06-developer-experience/build-engineer.md) - Build system specialist
 - [**cli-developer**](categories/06-developer-experience/cli-developer.md) - Command-line tool creator
 - [**dependency-manager**](categories/06-developer-experience/dependency-manager.md) - Package and dependency specialist


### PR DESCRIPTION
## Summary

Adds [agent-lsp](https://github.com/blackwell-systems/agent-lsp) to the Development Experience category.

agent-lsp is an LSP-powered code intelligence MCP server that provides:
- **66 code intelligence tools** across 30 languages
- **24 workflow skills** for safe refactoring, workspace-wide renames, and impact analysis
- Semantic code understanding via LSP instead of text-based grep/sed

## Why this fits

agent-lsp belongs in Development Experience alongside  and  because it's infrastructure that enables agents to understand code structure programmatically. It provides go-to-definition, find-references, call-hierarchy, and blast-radius analysis as building blocks for higher-level agent workflows.

## Installation

```bash
npm install -g @blackwell-systems/agent-lsp
```

Documentation: https://agent-lsp.com