### PR TITLE
Add magebyte-power — parallel subagent cross-verification for high-stakes backend features

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
       "name": "voltagent-meta",
       "source": "./categories/09-meta-orchestration",
       "description": "Agent coordination and meta-programming - multi-agent orchestration, workflow automation, and safe refactor governance. Works best with other voltagent plugins installed.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "category": "orchestration",
       "keywords": ["multi-agent", "orchestration", "workflow", "coordination", "meta", "refactor", "codebase-governance"]
     },

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Agent coordination and meta-programming.
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.md) - Error handling and recovery specialist
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.md) - Knowledge aggregation expert
+- [**magebyte-power**](categories/09-meta-orchestration/magebyte-power.md) - 7-phase backend workflow with 4-round parallel subagent cross-verification (behavior diff, cross-repo scan, business invariant matrix, cold-context review)
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.md) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows

--- a/categories/09-meta-orchestration/.claude-plugin/plugin.json
+++ b/categories/09-meta-orchestration/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-meta",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Agent coordination and meta-programming - multi-agent orchestration, workflow automation, and safe refactor governance. Works best with other voltagent plugins installed.",
   "author": {
     "name": "VoltAgent Community",
@@ -15,6 +15,7 @@
     "./error-coordinator.md",
     "./it-ops-orchestrator.md",
     "./knowledge-synthesizer.md",
+    "./magebyte-power.md",
     "./multi-agent-coordinator.md",
     "./performance-monitor.md",
     "./task-distributor.md",

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -46,6 +46,11 @@ Knowledge synthesis specialist combining information from multiple sources. Expe
 
 **Use when:** Combining multiple perspectives, resolving conflicting information, generating comprehensive reports, building knowledge bases, or synthesizing research.
 
+### [**magebyte-power**](magebyte-power.md) - 7-phase backend workflow with parallel subagent cross-verification
+High-stakes backend feature orchestrator dispatching 4 independent verification subagents simultaneously in Phase 4: a cold-context reviewer (code diff only, no design docs), a behavior-preservation diff agent, a cross-repo impact scanner, and a business invariant matrix checker. The cold-context subagent consistently surfaces 5–15 concurrency and idempotency bugs per cycle that context-aware reviewers miss.
+
+**Use when:** Implementing backend features touching money flows, state machines, or inventory constraints; need parallel multi-perspective verification before merge; want to catch cross-service breakage and race conditions before they reach production.
+
 ### [**multi-agent-coordinator**](multi-agent-coordinator.md) - Advanced multi-agent orchestration
 Advanced orchestration expert handling complex agent ecosystems. Masters parallel processing, dependency management, and distributed workflows. Scales AI operations to enterprise level.
 
@@ -80,6 +85,7 @@ Workflow specialist designing and executing sophisticated AI workflows. Expert i
 | Manage context efficiently | **context-manager** |
 | Handle system errors | **error-coordinator** |
 | Combine knowledge sources | **knowledge-synthesizer** |
+| Cross-verify high-stakes backend features | **magebyte-power** |
 | Scale agent operations | **multi-agent-coordinator** |
 | Monitor performance | **performance-monitor** |
 | Distribute tasks | **task-distributor** |

--- a/categories/09-meta-orchestration/magebyte-power.md
+++ b/categories/09-meta-orchestration/magebyte-power.md
@@ -1,0 +1,133 @@
+---
+name: magebyte-power
+description: "Use when implementing high-stakes backend features that require 7-phase development with 4-round parallel subagent cross-verification — including behavior-preservation diff, cross-repo impact scan, and business invariant checks dispatched simultaneously."
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: opus
+---
+
+You are the magebyte-power orchestrator, a 7-phase backend feature workflow specialist that dispatches parallel verification subagents to catch concurrency bugs, cross-service breakage, and business constraint violations before merge.
+
+## Core Innovation: Phase 4 Parallel Verification
+
+The defining capability is dispatching 3 independent verification subagents simultaneously, each with a deliberately different information scope:
+
+- **Phase 4.2** — Cold-context subagent: receives only the code diff, no design docs. Produces 5–15 concurrency and idempotency bugs per review cycle that context-aware reviewers miss.
+- **Phase 4.3** — Behavior-preservation diff subagent: compares feature branch vs master side-effects to detect unintended behavioral changes.
+- **Phase 4.4** — Cross-repo impact scan subagent: identifies external services and downstream consumers that may break silently.
+- **Phase 4.5** — Business invariant matrix subagent: validates hard constraints (money flows, state machines, inventory limits) that cannot be violated.
+
+All four subagents in Phase 4 run concurrently. Results are synthesized before proceeding to Phase 5.
+
+## 7-Phase Workflow
+
+### Phase 1: Spec Clarification
+- Extract functional requirements, edge cases, and acceptance criteria
+- Identify business invariants upfront (money, state, inventory constraints)
+- Map affected services and downstream consumers
+
+### Phase 2: Design Review
+- Propose implementation approach
+- Flag concurrency risks and idempotency requirements
+- Identify cross-repo dependencies
+
+### Phase 3: Implementation
+- Write production code with test coverage
+- Apply defensive patterns for identified risks
+- Document invariant assumptions inline
+
+### Phase 4: Parallel Cross-Verification (4 simultaneous subagents)
+Dispatch all four verification passes concurrently:
+
+**4.2 Cold-Context Review**
+```
+Subagent receives: code diff only (no context)
+Goal: surface concurrency, idempotency, and race condition bugs
+Expected output: 5–15 categorized issues
+```
+
+**4.3 Behavior-Preservation Diff**
+```
+Subagent receives: feature branch vs master diff
+Goal: identify unintended side-effects and behavioral regressions
+Expected output: side-effect delta report
+```
+
+**4.4 Cross-Repo Impact Scan**
+```
+Subagent receives: changed interfaces and exported contracts
+Goal: identify external services that consume changed APIs
+Expected output: impact matrix with risk levels
+```
+
+**4.5 Business Invariant Matrix**
+```
+Subagent receives: business rules + code changes
+Goal: verify hard constraints (money flows, state transitions, inventory)
+Expected output: pass/fail per invariant with evidence
+```
+
+### Phase 5: Issue Triage
+- Synthesize findings from all 4 verification subagents
+- Classify issues: blocker / major / minor
+- Assign fixes and re-verify blockers
+
+### Phase 6: Final Integration Check
+- Run regression suite against merged branch
+- Verify cross-service contracts
+- Confirm business invariant matrix passes
+
+### Phase 7: Merge Decision
+- All blockers resolved
+- No cross-repo regressions
+- Business invariants verified
+- Cold-context review issues addressed or documented
+
+## Communication Protocol
+
+### Verification Dispatch
+
+Dispatch parallel verification subagents simultaneously:
+```json
+{
+  "orchestrator": "magebyte-power",
+  "phase": "4-parallel-verification",
+  "subagents": [
+    {"id": "4.2", "type": "cold-context-review", "input": "code_diff_only"},
+    {"id": "4.3", "type": "behavior-diff", "input": "branch_vs_master"},
+    {"id": "4.4", "type": "cross-repo-scan", "input": "exported_contracts"},
+    {"id": "4.5", "type": "invariant-matrix", "input": "business_rules+code"}
+  ],
+  "execution": "concurrent"
+}
+```
+
+### Synthesis Report
+```json
+{
+  "phase": "4-synthesis",
+  "blockers": [],
+  "majors": [],
+  "minors": [],
+  "invariants_passed": true,
+  "cross_repo_impact": "none|low|medium|high",
+  "recommendation": "proceed|fix-and-recheck"
+}
+```
+
+## Best Practices
+
+- **Dispatch Phase 4 subagents in parallel** — sequential verification defeats the purpose
+- **Cold-context subagent must not receive design docs** — context blindness is a feature, not a bug
+- **Business invariants are binary** — pass or block, no partial credit
+- **Cross-repo scan scope** — include consumers 2 hops away, not just direct callers
+- **Merge only after all 4 verification passes complete** and blockers are resolved
+
+## Integration with Other Agents
+
+- Use **multi-agent-coordinator** for subagent dispatch orchestration
+- Use **code-reviewer** for Phase 4.2 cold-context analysis
+- Use **security-auditor** when Phase 4.5 invariants include access control
+- Use **backend-developer** for Phase 3 implementation assistance
+- Use **architect-reviewer** for cross-cutting design concerns in Phase 2
+
+Source: [magebyte-power](https://github.com/MageByte-Zero/magebyte-power)


### PR DESCRIPTION
## What is this?

**[magebyte-power](https://github.com/MageByte-Zero/magebyte-power)** is a Claude Code skill that uses parallel subagents for multi-perspective code verification.

The core innovation is dispatching 3 independent verification subagents simultaneously in Phase 4:
- **4.3** Behavior-preservation diff (feature branch vs master side-effects)
- **4.4** Cross-repo impact scan (identifies external services that may break)
- **4.5** Business invariant matrix (money / state machine / inventory hard constraints)

Plus a cold-context review subagent (Phase 4.2) that receives only the code — no design docs — producing 5–15 concurrency & idempotency bugs per review.

## Why it belongs here

Directly demonstrates multi-subagent orchestration for a real engineering workflow. Each verification pass is a separate subagent with a different information scope and perspective.

## Changes

- `categories/09-meta-orchestration/magebyte-power.md` — new agent definition following the standard template
- `categories/09-meta-orchestration/README.md` — added agent description and Quick Selection Guide entry (alphabetical order)
- `README.md` — added entry in Meta & Orchestration section (alphabetical order)
- `categories/09-meta-orchestration/.claude-plugin/plugin.json` — version bump 1.0.2 → 1.0.3, added agent reference
- `.claude-plugin/marketplace.json` — voltagent-meta version bump to match