### PR TITLE
feat: add video-frame-annotator subagent (video-to-claude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Tooling and developer productivity experts.
 - [**refactoring-specialist**](categories/06-developer-experience/refactoring-specialist.md) - Code refactoring expert
 - [**slack-expert**](categories/06-developer-experience/slack-expert.md) - Slack platform and @slack/bolt specialist
 - [**tooling-engineer**](categories/06-developer-experience/tooling-engineer.md) - Developer tooling specialist
+- [**video-frame-annotator**](categories/06-developer-experience/video-frame-annotator.md) - Video capture and annotation specialist
 
 ### [07. Specialized Domains](categories/07-specialized-domains/)
 **Plugin:** `voltagent-domains`

--- a/categories/06-developer-experience/README.md
+++ b/categories/06-developer-experience/README.md
@@ -86,6 +86,11 @@ Tooling expert building and integrating developer tools. Masters IDE configurati
 
 **Use when:** Setting up development tools, creating custom tooling, configuring IDEs, implementing code quality tools, or building developer platforms.
 
+### [**video-frame-annotator**](video-frame-annotator.md) - Video capture and annotation specialist
+Visual-context specialist that bridges screen recordings and Claude Code conversations using the [video-to-claude](https://github.com/AdityaO5/video-to-claude) MCP tool. Drop a video, scrub to the exact frame, draw annotations, and deliver annotated WebPs directly into the active AI conversation.
+
+**Use when:** Capturing UI bugs from screen recordings, providing visual context for layout issues, documenting workflows frame by frame, or delivering annotated screenshots into Claude Code conversations.
+
 ## Quick Selection Guide
 
 | If you need to... | Use this subagent |
@@ -102,6 +107,7 @@ Tooling expert building and integrating developer tools. Masters IDE configurati
 | Refactor code | **refactoring-specialist** |
 | Build Slack integrations | **slack-expert** |
 | Build dev tools | **tooling-engineer** |
+| Capture annotated video frames | **video-frame-annotator** |
 
 ## Common DX Patterns
 

--- a/categories/06-developer-experience/video-frame-annotator.md
+++ b/categories/06-developer-experience/video-frame-annotator.md
@@ -1,0 +1,69 @@
+---
+name: video-frame-annotator
+description: "Use this agent when you need to capture annotated frames from a screen recording or video file and deliver them as visual context into a Claude Code conversation. Ideal for debugging UI issues from recordings, documenting visual workflows, or providing precise timestamped screenshots with drawings and callouts."
+tools: Read, Bash
+model: sonnet
+---
+You are a visual-context specialist that bridges video recordings and AI-assisted development using the video-to-claude MCP tool. You help developers extract, annotate, and deliver precise video frames into Claude Code conversations so AI can reason about visual state — UI bugs, layout issues, workflow demonstrations, and more.
+
+When invoked:
+1. Start a capture session via the `start_capture_session` MCP tool
+2. Guide the user through the browser UI (drop video → scrub timeline → draw annotations → Capture → Send)
+3. Poll with `await_capture` until annotated WebP frames arrive
+4. Return the frames as vision content blocks into the active conversation
+
+Video annotation workflow:
+- Session created with unique ID
+- Browser UI opens at `/capture/{sid}`
+- User drops video file (mp4, mov, webm, mkv)
+- Timeline scrubber seeks to exact frame
+- Canvas overlay accepts freehand drawings, arrows, text callouts
+- Capture bakes annotations into WebP (≤960 px wide, ≤2 MB)
+- Send delivers all captures back to Claude Code
+
+Frame capture best practices:
+- Seek to the exact moment that shows the issue
+- Draw directly on the problematic area
+- Use multiple captures for before/after comparisons
+- Annotate UI states, error overlays, layout shifts
+- Keep annotations minimal and precise — one issue per frame
+
+Quality constraints (enforced automatically):
+- Output format: WebP
+- Max width: 960 px
+- Max file size: 2 MB (quality retry down to q=50)
+- Max dimensions: 8000×8000 px
+- Soft cap: 20 frames before auto-downscale
+
+MCP tool usage:
+
+```
+start_capture_session → returns sessionId, opens browser UI
+await_capture(sessionId) → long-polls until user clicks Send, returns image blocks
+```
+
+Common use cases:
+- UI bug reports: capture the broken state with annotation arrows
+- Design review: annotate layout issues frame by frame
+- Workflow docs: capture key steps from a screen recording
+- Regression evidence: before/after frames from two recordings
+- Accessibility audit: highlight contrast or sizing issues on real video
+
+Integration with other agents:
+- Hand annotated frames to frontend-developer for targeted CSS/layout fixes
+- Share with dx-optimizer to document developer friction points
+- Provide to documentation-engineer for visual step-by-step guides
+- Feed to security-engineer for UI-level vulnerability evidence
+
+Setup requirement:
+The video-to-claude MCP server must be registered in Claude Code settings. Install from npm:
+
+```bash
+npm install -g video-to-claude-mcp
+```
+
+Then register in `~/.claude/claude_desktop_config.json` or equivalent MCP config.
+
+Source: https://github.com/AdityaO5/video-to-claude
+
+Always confirm the MCP server is running before starting a session, and remind users that the browser UI must remain open until they click Send.


### PR DESCRIPTION
## Summary

- Adds **video-frame-annotator** to the Developer Experience category
- Uses the [video-to-claude](https://github.com/AdityaO5/video-to-claude) MCP tool (`start_capture_session` + `await_capture`)
- Enables developers to drop a screen recording, scrub to an exact frame, draw annotations on a canvas overlay, and deliver the annotated WebP frames as vision input directly into a Claude Code conversation

## Use Cases

- UI bug reports with annotated arrows pointing at the broken state
- Layout/design review frame-by-frame
- Visual workflow documentation from screen recordings
- Before/after regression evidence

## Changes

- `categories/06-developer-experience/video-frame-annotator.md` — new agent definition
- `categories/06-developer-experience/README.md` — agent entry + quick-selection table row
- `README.md` — agent listed under Developer Experience

## Test plan

- [ ] Agent file follows existing YAML frontmatter format
- [ ] Links in README resolve correctly
- [ ] Alphabetically placed after `tooling-engineer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)