### PR TITLE
Add RunAPI MCP Server to Data & AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Data engineering, ML, and AI specialists.
 - [**postgres-pro**](categories/05-data-ai/postgres-pro.md) - PostgreSQL database expert
 - [**prompt-engineer**](categories/05-data-ai/prompt-engineer.md) - Prompt optimization specialist
 - [**reinforcement-learning-engineer**](categories/05-data-ai/reinforcement-learning-engineer.md) - Reinforcement learning and agent training expert
+- [**runapi-mcp-server**](https://github.com/runapi-ai/mcp) - MCP server exposing 130+ AI models for image, video, music, audio, and LLM generation from 18 providers — works in Claude Code via `npx @runapi.ai/mcp`
 
 ### [06. Developer Experience](categories/06-developer-experience/)
 **Plugin:** `voltagent-dev-exp`

--- a/categories/05-data-ai/README.md
+++ b/categories/05-data-ai/README.md
@@ -81,6 +81,11 @@ RL specialist designing environments, shaping rewards, and training agents with 
 
 **Use when:** Designing RL environments, training game AI or robotics agents, implementing policy gradient methods, optimizing reward functions, or deploying autonomous decision-making systems.
 
+### [**runapi-mcp-server**](https://github.com/runapi-ai/mcp) - Media generation MCP server
+MCP server that gives Claude Code access to 130+ AI models for image, video, music, audio, and LLM generation across 18 providers. Provides free catalog and pricing tools plus authenticated task creation. Install with `npx @runapi.ai/mcp`.
+
+**Use when:** Generating images, video, music, audio, or LLM completions from inside an agent, browsing available models, or wiring media generation into a multi-step workflow.
+
 ## Quick Selection Guide
 
 | If you need to... | Use this subagent |
@@ -98,6 +103,7 @@ RL specialist designing environments, shaping rewards, and training agents with 
 | Optimize PostgreSQL | **postgres-pro** |
 | Design AI prompts | **prompt-engineer** |
 | Train RL agents | **reinforcement-learning-engineer** |
+| Generate images, video, music, or audio | **runapi-mcp-server** |
 
 ## Common Data & AI Patterns
 


### PR DESCRIPTION
## What

Adds **RunAPI MCP Server** to the Data & AI category.

RunAPI MCP Server is a Model Context Protocol server that gives Claude Code (and other MCP-capable agents) access to 130+ AI models for image, video, music, audio, and LLM generation across 18 providers. It ships free catalog and pricing tools (no API key required) plus authenticated task creation and polling.

- Repo: https://github.com/runapi-ai/mcp
- npm: `@runapi.ai/mcp`
- Install: `npx @runapi.ai/mcp`

## Files changed

- `README.md` — added entry to the Data & AI list (alphabetical, external-link format matching existing meta/ecosystem tool entries)
- `categories/05-data-ai/README.md` — added Available Subagents description and Quick Selection Guide row

All links verified.