### PR TITLE
Add Guster-Ducks — personal agent toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Agent coordination and meta-programming.
 - [**codebase-orchestrator**](categories/09-meta-orchestration/codebase-orchestrator.md) - Safe refactor governance orchestrator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.md) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.md) - Error handling and recovery specialist
+- [**guster-ducks**](https://github.com/Lumos-789/Guster-Ducks) - Personal agent toolkit built on Claude Code. Markdown specs, zero infrastructure. Talk to Guster and manage the ducks
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.md) - Knowledge aggregation expert
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration


### PR DESCRIPTION
## Addition

Adding **Guster-Ducks** to the Meta & Orchestration category.

- **Repository**: https://github.com/Lumos-789/Guster-Ducks
- **Description**: Personal agent toolkit built on Claude Code. Markdown specs, zero infrastructure. Talk to Guster and manage the ducks.

Guster-Ducks is an open-source personal agent toolkit that orchestrates multiple Claude Code subagents through markdown-based specs — no infrastructure required. It provides path planning, bridges, workflows, and capability layers for managing personal projects and tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)