### PR TITLE
Add navox-agents: 15-agent sprint team with eval-gated reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Agent coordination and meta-programming.
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.md) - Knowledge aggregation expert
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration
+- [**navox-agents**](https://github.com/navox-labs/agents) - 15-agent sprint team with handoff contracts, eval-gated reliability (10/10 quality scores), 3 sprint modes (FULL/QUICK/HOTFIX), and a Python CLI for autonomous orchestration. Zero plugin dependencies
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.md) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows
 - [**task-distributor**](categories/09-meta-orchestration/task-distributor.md) - Task allocation specialist

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -46,6 +46,11 @@ Knowledge synthesis specialist combining information from multiple sources. Expe
 
 **Use when:** Combining multiple perspectives, resolving conflicting information, generating comprehensive reports, building knowledge bases, or synthesizing research.
 
+### [**navox-agents**](https://github.com/navox-labs/agents) - 15-agent sprint team with handoff contracts and eval-gated reliability
+Full sprint cycle orchestrator with 15 specialist agents covering Think, Plan, Build, Review, Test, Ship, and Reflect. Three sprint modes (FULL/QUICK/HOTFIX) chain agents automatically with parallel execution groups. Each agent has handoff contracts defining required inputs and outputs, self-validation checklists, and persistent memory. Built-in eval system scores every agent against a 10-point quality rubric (14/14 pass at 10/10). Available as a Claude Code plugin (zero dependencies, pure markdown) and as a Python CLI (`navox run full "your task"`) for autonomous orchestration with eval-gated retries.
+
+**Use when:** Running end-to-end development sprints with automated agent orchestration, enforcing quality gates between build and review stages, coordinating specialist agents (strategist, architect, fullstack, reviewer, QA, security, shipper) through structured handoff contracts, or running autonomous sprints via the CLI while you focus on other work. Install plugin: `claude plugin add navox-labs/agents` | Install CLI: `cd sdk && pip install -e .`
+
 ### [**multi-agent-coordinator**](multi-agent-coordinator.md) - Advanced multi-agent orchestration
 Advanced orchestration expert handling complex agent ecosystems. Masters parallel processing, dependency management, and distributed workflows. Scales AI operations to enterprise level.
 
@@ -80,6 +85,7 @@ Workflow specialist designing and executing sophisticated AI workflows. Expert i
 | Manage context efficiently | **context-manager** |
 | Handle system errors | **error-coordinator** |
 | Combine knowledge sources | **knowledge-synthesizer** |
+| Run full dev sprints with quality gates | **[navox-agents](https://github.com/navox-labs/agents)** |
 | Scale agent operations | **multi-agent-coordinator** |
 | Monitor performance | **performance-monitor** |
 | Distribute tasks | **task-distributor** |


### PR DESCRIPTION
## What this adds

[navox-agents](https://github.com/navox-labs/agents) — a 15-agent AI engineering team for Claude Code covering the full sprint cycle: Think, Plan, Build, Review, Test, Ship, Reflect.

**Category:** 09. Meta & Orchestration

**Why it fits this category:** navox-agents is a multi-agent orchestrator that chains 15 specialist agents through structured sprint modes (FULL/QUICK/HOTFIX) with handoff contracts, parallel execution groups, and eval-gated quality gates between stages.

**Key features:**
- 15 specialist agents (strategist, spec-writer, architect, UX, fullstack, investigator, reviewer, devops, local-review, QA, security, shipper, retro, context-manager, installer)
- 3 sprint modes: FULL (idea to PR), QUICK (skip strategy), HOTFIX (bug to fix to ship)
- Handoff contracts — each agent defines required inputs/outputs and self-validates before passing work downstream
- 10-point quality rubric — 14/14 scored agents at 10/10, 210/210 validation checks
- 7-specialist parallel code review army (security, performance, maintainability, API, data, tests, errors)
- Human-in-the-loop gates at every checkpoint
- Per-agent and shared project memory persisting across sprints
- Python CLI for autonomous orchestration (`navox run full "your task"`) with eval-gated retries (8/10 threshold)
- Zero plugin dependencies — pure markdown prompts

**Install plugin:** `claude plugin add navox-labs/agents`
**Install CLI:** `cd sdk && pip install -e .`

**License:** MIT

## Files changed

- `README.md` — added navox-agents entry in 09. Meta & Orchestration section (alphabetical order)
- `categories/09-meta-orchestration/README.md` — added detailed description, updated Quick Selection Guide