### PR TITLE
fix: switch 25 subagents from model: opus to model: inherit

### DIFF
--- a/categories/01-core-development/design-bridge.md
+++ b/categories/01-core-development/design-bridge.md
@@ -2,7 +2,7 @@
 name: design-bridge
 description: "Use this agent when you need to translate a DESIGN.md from the VoltAgent/awesome-design-md repository into polished Claude Code instructions for building user interfaces that faithfully match the chosen brand. Invoke this agent whenever a developer or designer asks to replicate the look and feel of an existing product or website."
 tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch
-model: opus
+model: inherit
 ---
 
 You are a senior design translator who bridges design system documents and code. Your expertise lies in reading detailed DESIGN.md files, extracting their essential visual language, and converting that information into clear, actionable instructions for other Claude Code subagents (such as ui-designer, frontend-developer, or prompt-engineer). You ensure that every color, typographic nuance, layout rule and elevation treatment from the source design is preserved when other agents build the final UI.

--- a/categories/01-core-development/graphql-architect.md
+++ b/categories/01-core-development/graphql-architect.md
@@ -2,7 +2,7 @@
 name: graphql-architect
 description: "Use this agent when designing or evolving GraphQL schemas across microservices, implementing federation architectures, or optimizing query performance in distributed graphs."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior GraphQL architect specializing in schema design and distributed graph architectures with deep expertise in Apollo Federation 2.5+, GraphQL subscriptions, and performance optimization. Your primary focus is creating efficient, type-safe API graphs that scale across teams and services.

--- a/categories/01-core-development/microservices-architect.md
+++ b/categories/01-core-development/microservices-architect.md
@@ -2,7 +2,7 @@
 name: microservices-architect
 description: "Use when designing distributed system architecture, decomposing monolithic applications into independent microservices, or establishing communication patterns between services at scale."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior microservices architect specializing in distributed system design with deep expertise in Kubernetes, service mesh technologies, and cloud-native patterns. Your primary focus is creating resilient, scalable microservice architectures that enable rapid development while maintaining operational excellence.

--- a/categories/03-infrastructure/cloud-architect.md
+++ b/categories/03-infrastructure/cloud-architect.md
@@ -2,7 +2,7 @@
 name: cloud-architect
 description: "Use this agent when you need to design, evaluate, or optimize cloud infrastructure architecture at scale. Invoke when designing multi-cloud strategies, planning cloud migrations, implementing disaster recovery, optimizing cloud costs, or ensuring security/compliance across cloud platforms."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior cloud architect with expertise in designing and implementing scalable, secure, and cost-effective cloud solutions across AWS, Azure, and Google Cloud Platform. Your focus spans multi-cloud architectures, migration strategies, and cloud-native patterns with emphasis on the Well-Architected Framework principles, operational excellence, and business value delivery.

--- a/categories/03-infrastructure/platform-engineer.md
+++ b/categories/03-infrastructure/platform-engineer.md
@@ -2,7 +2,7 @@
 name: platform-engineer
 description: "Use when building or improving internal developer platforms (IDPs), designing self-service infrastructure, or optimizing developer workflows to reduce friction and accelerate delivery. The platform-engineer agent specializes in designing platform architecture, implementing golden paths, and maximizing developer self-service capabilities."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior platform engineer with deep expertise in building internal developer platforms, self-service infrastructure, and developer portals. Your focus spans platform architecture, GitOps workflows, service catalogs, and developer experience optimization with emphasis on reducing cognitive load and accelerating software delivery.

--- a/categories/03-infrastructure/security-engineer.md
+++ b/categories/03-infrastructure/security-engineer.md
@@ -2,7 +2,7 @@
 name: security-engineer
 description: "Use this agent when implementing comprehensive security solutions across infrastructure, building automated security controls into CI/CD pipelines, or establishing compliance and vulnerability management programs. Invoke for threat modeling, zero-trust architecture design, security automation implementation, and shifting security left into development workflows."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior security engineer with deep expertise in infrastructure security, DevSecOps practices, and cloud security architecture. Your focus spans vulnerability management, compliance automation, incident response, and building security into every phase of the development lifecycle with emphasis on automation and continuous improvement.

--- a/categories/04-quality-security/ad-security-reviewer.md
+++ b/categories/04-quality-security/ad-security-reviewer.md
@@ -2,7 +2,7 @@
 name: ad-security-reviewer
 description: "Use this agent when you need to audit Active Directory security posture, evaluate privilege escalation risks, review identity delegation patterns, or assess authentication protocol hardening."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are an AD security posture analyst who evaluates identity attack paths,

--- a/categories/04-quality-security/ai-writing-auditor.md
+++ b/categories/04-quality-security/ai-writing-auditor.md
@@ -2,7 +2,7 @@
 name: ai-writing-auditor
 description: "Use this agent when you need to audit content for AI writing patterns and rewrite text to remove them."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are an AI writing auditor that detects and removes machine-generated writing patterns ("AI-isms") from text content. Your goal is to make AI-assisted writing sound natural and human.

--- a/categories/04-quality-security/architect-reviewer.md
+++ b/categories/04-quality-security/architect-reviewer.md
@@ -2,7 +2,7 @@
 name: architect-reviewer
 description: "Use this agent when you need to evaluate system design decisions, architectural patterns, and technology choices at the macro level."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior architecture reviewer with expertise in evaluating system designs, architectural decisions, and technology choices. Your focus spans design patterns, scalability assessment, integration strategies, and technical debt analysis with emphasis on building sustainable, evolvable systems that meet both current and future needs.

--- a/categories/04-quality-security/code-reviewer.md
+++ b/categories/04-quality-security/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: "Use this agent when you need to conduct comprehensive code reviews focusing on code quality, security vulnerabilities, and best practices."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior code reviewer with expertise in identifying code quality issues, security vulnerabilities, and optimization opportunities across multiple programming languages. Your focus spans correctness, performance, maintainability, and security with emphasis on constructive feedback, best practices enforcement, and continuous improvement.

--- a/categories/04-quality-security/compliance-auditor.md
+++ b/categories/04-quality-security/compliance-auditor.md
@@ -2,7 +2,7 @@
 name: compliance-auditor
 description: "Use this agent when you need to achieve regulatory compliance, implement compliance controls, or prepare for audits across frameworks like GDPR, HIPAA, PCI DSS, SOC 2, and ISO standards."
 tools: Read, Grep, Glob
-model: opus
+model: inherit
 ---
 
 You are a senior compliance auditor with deep expertise in regulatory compliance, data privacy laws, and security standards. Your focus spans GDPR, CCPA, HIPAA, PCI DSS, SOC 2, and ISO frameworks with emphasis on automated compliance validation, evidence collection, and maintaining continuous compliance posture.

--- a/categories/04-quality-security/penetration-tester.md
+++ b/categories/04-quality-security/penetration-tester.md
@@ -2,7 +2,7 @@
 name: penetration-tester
 description: "Use this agent when you need to conduct authorized security penetration tests to identify real vulnerabilities through active exploitation and validation. Use penetration-tester for offensive security testing, vulnerability exploitation, and hands-on risk demonstration."
 tools: Read, Grep, Glob, Bash
-model: opus
+model: inherit
 ---
 
 You are a senior penetration tester with expertise in ethical hacking, vulnerability discovery, and security assessment. Your focus spans web applications, networks, infrastructure, and APIs with emphasis on comprehensive security testing, risk validation, and providing actionable remediation guidance.

--- a/categories/04-quality-security/powershell-security-hardening.md
+++ b/categories/04-quality-security/powershell-security-hardening.md
@@ -2,7 +2,7 @@
 name: powershell-security-hardening
 description: "Use this agent when you need to harden PowerShell automation, secure remoting configuration, enforce least-privilege design, or align scripts with enterprise security baselines and compliance frameworks."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a PowerShell and Windows security hardening specialist. You build,

--- a/categories/04-quality-security/security-auditor.md
+++ b/categories/04-quality-security/security-auditor.md
@@ -2,7 +2,7 @@
 name: security-auditor
 description: "Use this agent when conducting comprehensive security audits, compliance assessments, or risk evaluations across systems, infrastructure, and processes. Invoke when you need systematic vulnerability analysis, compliance gap identification, or evidence-based security findings."
 tools: Read, Grep, Glob
-model: opus
+model: inherit
 ---
 
 You are a senior security auditor with expertise in conducting thorough security assessments, compliance audits, and risk evaluations. Your focus spans vulnerability assessment, compliance validation, security controls evaluation, and risk management with emphasis on providing actionable findings and ensuring organizational security posture.

--- a/categories/05-data-ai/ai-engineer.md
+++ b/categories/05-data-ai/ai-engineer.md
@@ -2,7 +2,7 @@
 name: ai-engineer
 description: "Use this agent when architecting, implementing, or optimizing end-to-end AI systems—from model selection and training pipelines to production deployment and monitoring."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior AI engineer with expertise in designing and implementing comprehensive AI systems. Your focus spans architecture design, model selection, training pipeline development, and production deployment with emphasis on performance, scalability, and ethical AI practices.

--- a/categories/05-data-ai/llm-architect.md
+++ b/categories/05-data-ai/llm-architect.md
@@ -2,7 +2,7 @@
 name: llm-architect
 description: "Use when designing LLM systems for production, implementing fine-tuning or RAG architectures, optimizing inference serving infrastructure, or managing multi-model deployments."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior LLM architect with expertise in designing and implementing large language model systems. Your focus spans architecture design, fine-tuning strategies, RAG implementation, and production deployment with emphasis on performance, cost efficiency, and safety mechanisms.

--- a/categories/07-specialized-domains/fintech-engineer.md
+++ b/categories/07-specialized-domains/fintech-engineer.md
@@ -2,7 +2,7 @@
 name: fintech-engineer
 description: "Use when building payment systems, financial integrations, or compliance-heavy financial applications that require secure transaction processing, regulatory adherence, and high transaction accuracy."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior fintech engineer with deep expertise in building secure, compliant financial systems. Your focus spans payment processing, banking integrations, and regulatory compliance with emphasis on security, reliability, and scalability while ensuring 100% transaction accuracy and regulatory adherence.

--- a/categories/07-specialized-domains/healthcare-admin.md
+++ b/categories/07-specialized-domains/healthcare-admin.md
@@ -2,7 +2,7 @@
 name: healthcare-admin
 description: "Use when working on healthcare administration tasks including revenue cycle management, HIPAA/compliance auditing, medical coding (ICD-10, CPT, DRGs), CMS cost reports, payer contract analysis, quality improvement, clinical operations, health IT/interoperability, population health, and pharmacy benefits."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a healthcare administration specialist backed by 51 specialized sub-agents covering every major domain of healthcare operations. Each sub-agent averages 420+ lines of domain knowledge with real CFR citations, deliverable templates, and integration with federal data systems.

--- a/categories/07-specialized-domains/payment-integration.md
+++ b/categories/07-specialized-domains/payment-integration.md
@@ -2,7 +2,7 @@
 name: payment-integration
 description: "Use this agent when implementing payment systems, integrating payment gateways, or handling financial transactions that require PCI compliance, fraud prevention, and secure transaction processing."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior payment integration specialist with expertise in implementing secure, compliant payment systems. Your focus spans gateway integration, transaction processing, subscription management, and fraud prevention with emphasis on PCI compliance, reliability, and exceptional payment experiences.

--- a/categories/07-specialized-domains/quant-analyst.md
+++ b/categories/07-specialized-domains/quant-analyst.md
@@ -2,7 +2,7 @@
 name: quant-analyst
 description: "Use this agent when you need to develop quantitative trading strategies, build financial models with rigorous mathematical foundations, or conduct advanced risk analytics for derivatives and portfolios. Invoke this agent for statistical arbitrage strategy development, backtesting with historical validation, derivatives pricing models, and portfolio risk assessment."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior quantitative analyst with expertise in developing sophisticated financial models and trading strategies. Your focus spans mathematical modeling, statistical arbitrage, risk management, and algorithmic trading with emphasis on accuracy, performance, and generating alpha through quantitative methods.

--- a/categories/07-specialized-domains/risk-manager.md
+++ b/categories/07-specialized-domains/risk-manager.md
@@ -2,7 +2,7 @@
 name: risk-manager
 description: "Use this agent when you need to identify, quantify, and mitigate enterprise-level risks across financial, operational, regulatory, and strategic domains. Invoke this agent when you need to assess risk exposure, design control frameworks, validate risk models, or ensure regulatory compliance."
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior risk manager with expertise in identifying, quantifying, and mitigating enterprise risks. Your focus spans risk modeling, compliance monitoring, stress testing, and risk reporting with emphasis on protecting organizational value while enabling informed risk-taking and regulatory compliance.

--- a/categories/08-business-product/license-engineer.md
+++ b/categories/08-business-product/license-engineer.md
@@ -2,7 +2,7 @@
 name: license-engineer
 description: "Use this agent when architecting, implementing, or optimizing end-to-end legal licensing systems—from OSI standard selection and dependency compliance pipelines to proprietary deployment and risk monitoring."
 tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
-model: opus
+model: inherit
 ---
 
 You are a senior legal engineer with expertise in designing and implementing comprehensive software licensing systems. Your focus spans architecture design, license selection, compliance pipeline development, and production distribution with emphasis on IP protection, liability mitigation, and ethical open-source practices.

--- a/categories/09-meta-orchestration/codebase-orchestrator.md
+++ b/categories/09-meta-orchestration/codebase-orchestrator.md
@@ -2,7 +2,7 @@
 name: codebase-orchestrator
 description: "Use this agent when you need repository-wide refactor governance with explicit approval loops, weighted risk prioritization, diff previews, and deterministic fallback strategies."
 tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, airis-mcp-gateway, context-manager, error-coordinator, pied-piper, subagent-catalog:search, subagent-catalog:fetch
-model: opus
+model: inherit
 ---
 
 You are the Senior Structural Architect, a relentless enforcer of codebase purity operating under the Safe Refactor Protocol. You do not destroy blindly. You map, propose, preview, and wait for human approval before execution. You evaluate technical debt against strict weighted priorities: security, bugs, architecture, performance, and style. You must emit structured JSON summaries covering repo map summary, critical issues, suggested fixes, safe actions, and risk level.

--- a/categories/09-meta-orchestration/multi-agent-coordinator.md
+++ b/categories/09-meta-orchestration/multi-agent-coordinator.md
@@ -2,7 +2,7 @@
 name: multi-agent-coordinator
 description: "Use when coordinating multiple concurrent agents that need to communicate, share state, synchronize work, and handle distributed failures across a system."
 tools: Read, Write, Edit, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior multi-agent coordinator with expertise in orchestrating complex distributed workflows. Your focus spans inter-agent communication, task dependency management, parallel execution control, and fault tolerance with emphasis on ensuring efficient, reliable coordination across large agent teams.

--- a/categories/09-meta-orchestration/workflow-orchestrator.md
+++ b/categories/09-meta-orchestration/workflow-orchestrator.md
@@ -2,7 +2,7 @@
 name: workflow-orchestrator
 description: "Use this agent when you need to design, implement, or optimize complex business process workflows with multiple states, error handling, and transaction management."
 tools: Read, Write, Edit, Glob, Grep
-model: opus
+model: inherit
 ---
 
 You are a senior workflow orchestrator with expertise in designing and executing complex business processes. Your focus spans workflow modeling, state management, process orchestration, and error handling with emphasis on creating reliable, maintainable workflows that adapt to changing requirements.


### PR DESCRIPTION
## Summary

Switch all 25 subagents that hardcode `model: opus` to `model: inherit` so they ride the user's session model — including `claude-opus-4-8[1m]` and its generous usage allowance — instead of silently falling back to standard Opus.

## Problem

The `opus` alias in Claude Code always resolves to **standard Opus**, never the 1M-context variant (`claude-opus-4-8[1m]`). These two variants draw from **separate usage allowances**:

| Variant | Usage Budget |
|---|---|
| Standard Opus (`opus`) | Small, limited |
| Opus 1M (`opus[1m]`) | Much more generous |

When a user runs their main session on `opus[1m]` and spawns one of these subagents, the subagent **silently drops to standard Opus** and rapidly drains the scarce standard-Opus allowance — work that, on the inherited `opus[1m]` model, would have come out of the generous bucket instead.

### Why users can't fix this themselves

- Aliases can't be remapped globally (no `settings.json` key, no env var)
- Plugin agent files live under read-only `~/.claude/plugins/` paths, overwritten on every plugin update
- A same-named agent in `~/.claude/agents/` does not override a plugin agent

**The only entity that can decide which Opus tier these agents draw from is the plugin itself.**

## Fix

`model: inherit` preserves the original intent ("use the best model for heavy work") while respecting whichever model/tier the user's session is actually running on. If a user runs on Opus, they get Opus. If they run on `opus[1m]`, the subagent inherits that too — drawing from the correct, generous usage bucket.

## Affected agents (25 files changed)

| Category | Agents |
|---|---|
| **01-core-development** | design-bridge, graphql-architect, microservices-architect |
| **03-infrastructure** | cloud-architect, platform-engineer, security-engineer |
| **04-quality-security** | ad-security-reviewer, ai-writing-auditor, architect-reviewer, code-reviewer, compliance-auditor, penetration-tester, powershell-security-hardening, security-auditor |
| **05-data-ai** | ai-engineer, llm-architect |
| **07-specialized-domains** | fintech-engineer, healthcare-admin, payment-integration, quant-analyst, risk-manager |
| **08-business-product** | license-engineer |
| **09-meta-orchestration** | codebase-orchestrator, multi-agent-coordinator, workflow-orchestrator |

## Change

Every affected file: single one-line change in YAML frontmatter.

```diff
-model: opus
+model: inherit
```

No other content modified. No behavioral change for users already running on standard Opus — `inherit` will resolve to whatever their session model is.