### PR TITLE
Add OpenClacky to Alternative Claude Code Clients — 93.8% cache hit rate, 0.8x cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,12 @@ Claude Code skill for browsing and fetching subagents from this catalog.
 cp -r tools/subagent-catalog ~/.claude/commands/
 ```
 
+### Alternative Claude Code Clients
+
+Open-source agents that are compatible with or serve as alternatives to Claude Code:
+
+- [**OpenClacky**](https://openclacky.com) — Open-source AI coding agent (MIT). Achieves **93.8% Prompt Cache hit rate** and **~0.8× the API cost of Claude Code** via frozen 16-tool schema, dual cache markers, and Insert-then-Compress context management. Supports Claude, GPT-4, DeepSeek, Gemini, and OpenRouter (BYOK). [GitHub](https://github.com/clacky-ai/open-clacky)
+
 
 
 ## 🤝 Contributing


### PR DESCRIPTION
## What's being added

[OpenClacky](https://openclacky.com) — open-source Claude Code alternative, added to a new **Alternative Claude Code Clients** section under Tools.

GitHub: https://github.com/clacky-ai/open-clacky

## Why it belongs here

OpenClacky is a drop-in Claude Code alternative for developers who want the same Claude-powered coding experience at a lower cost. It achieves:

- **93.8% Prompt Cache hit rate** (7-day global average, measured via Anthropic's cache_read_input_tokens API response)
- **~0.8x the API cost** of a comparable Claude Code session

This is achieved through:
1. Frozen 16-tool schema — the exact same tool definitions every session, so Anthropic's cache never expires
2. Dual cache markers — both the system block and tool definitions carry cache_control markers
3. Insert-then-Compress — older context is summarized rather than dropped, keeping the cached prefix intact
4. No tool-order churn that would bust the cache

**Features**: Web UI + CLI, BYOK (Claude/GPT-4/DeepSeek/Gemini/OpenRouter), Skill extensions, browser automation, IM integration (Feishu/WeChat Work/Discord/Telegram/DingTalk), scheduled tasks, long-term memory.

**License**: MIT
**Website**: https://openclacky.com