### PR TITLE
Add ForgeDock — autonomous dev pipeline for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Agent coordination and meta-programming.
 - [**codebase-orchestrator**](categories/09-meta-orchestration/codebase-orchestrator.md) - Safe refactor governance orchestrator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.md) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.md) - Error handling and recovery specialist
+- [**forgedock**](https://github.com/RapierCraftStudios/ForgeDock) - Autonomous dev pipeline that dispatches parallel agents for investigate → architect → build → review → merge workflows, using GitHub as a structured knowledge graph
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.md) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.md) - Knowledge aggregation expert
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.md) - Advanced multi-agent orchestration

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -36,6 +36,11 @@ Error handling expert ensuring graceful failure recovery. Masters error patterns
 
 **Use when:** Implementing error handling, designing recovery strategies, managing cascading failures, monitoring system health, or building resilient workflows.
 
+### [**forgedock**](https://github.com/RapierCraftStudios/ForgeDock) - Autonomous dev pipeline for Claude Code
+Orchestration layer that dispatches parallel Claude Code agents through a structured investigate → architect → build → review → merge pipeline. Uses GitHub issues, labels, and PR comments as a knowledge graph — agents pass context via machine-readable FORGE: annotations, reconstruct full state from GitHub alone, and coordinate through 20+ slash-command specs. Installs via npx with zero runtime dependencies.
+
+**Use when:** Running autonomous end-to-end development workflows, orchestrating parallel agents across investigation/build/review phases, using GitHub as a structured context store for agent coordination, or managing multi-issue pipelines with full traceability.
+
 ### [**it-ops-orchestrator**](it-ops-orchestrator.md) - IT operations meta-orchestrator for PowerShell/.NET ecosystems
 Meta-orchestrator that routes ambiguous infrastructure and operations tasks to the right specialist agents, with a strong preference for PowerShell and .NET-based workflows. Understands the roles of Windows infra, Azure, M365, and PowerShell language experts, and coordinates them to deliver end-to-end solutions.
 
@@ -79,6 +84,7 @@ Workflow specialist designing and executing sophisticated AI workflows. Expert i
 | Govern safe repo refactors | **codebase-orchestrator** |
 | Manage context efficiently | **context-manager** |
 | Handle system errors | **error-coordinator** |
+| Run autonomous dev pipelines | **[forgedock](https://github.com/RapierCraftStudios/ForgeDock)** |
 | Combine knowledge sources | **knowledge-synthesizer** |
 | Scale agent operations | **multi-agent-coordinator** |
 | Monitor performance | **performance-monitor** |


### PR DESCRIPTION
## Summary

- Adds [ForgeDock](https://github.com/RapierCraftStudios/ForgeDock) to the **09. Meta & Orchestration** category
- ForgeDock is an orchestration layer for Claude Code that dispatches parallel agents through investigate → architect → build → review → merge workflows, using GitHub as a structured knowledge graph
- Agents coordinate via machine-readable FORGE: annotations on issues/PRs and reconstruct full context from GitHub alone
- Installs via `npx forgedock` with zero runtime dependencies — ships as 20+ slash-command specs

## Files updated

- **README.md** — added entry in Meta & Orchestration section (alphabetical order)
- **categories/09-meta-orchestration/README.md** — added detailed description, use-when guidance, and Quick Selection Guide row