### PR TITLE
feat: add NotFair - open-source Claude Code skills for SEO and paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Product management and business analysis.
 - [**growth-loops**](categories/08-business-product/growth-loops.md) - Growth loop and PLG mechanics specialist
 - [**legal-advisor**](categories/08-business-product/legal-advisor.md) - Legal and compliance specialist
 - [**license-engineer**](categories/08-business-product/license-engineer.md) - Software licensing and compliance systems specialist
+- [**notfair**](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP
 - [**product-manager**](categories/08-business-product/product-manager.md) - Product strategy expert
 - [**project-manager**](categories/08-business-product/project-manager.md) - Project management specialist
 - [**sales-engineer**](categories/08-business-product/sales-engineer.md) - Technical sales expert

--- a/categories/08-business-product/README.md
+++ b/categories/08-business-product/README.md
@@ -58,6 +58,11 @@ Licensing systems expert designing OSS and proprietary licensing architectures f
 
 **Use when:** Selecting open source licenses, designing dual-licensing models, auditing dependency compatibility, implementing notice and attribution workflows, or preparing software for SaaS, enterprise, app store, or embedded distribution.
 
+### [**notfair**](https://github.com/nowork-studio/NotFair) - SEO, GEO, Google Ads, and Meta Ads skills
+Open-source collection of Claude Code skills for marketing and paid ads. Covers SEO site analysis, keyword research, meta tags, schema markup, and GEO optimization; Google Ads audits, wasted-spend detection, and bid management; and Meta (Facebook + Instagram) Ads ROAS, creative fatigue, and audience overlap analysis. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+
+**Use when:** Running SEO audits, optimizing paid search or social campaigns, detecting wasted ad spend, or automating marketing workflows from within Claude Code.
+
 ### [**product-manager**](product-manager.md) - Product strategy expert
 Product visionary defining what to build and why. Expert in market analysis, user needs, and product strategy. Drives product success from conception to market leadership.
 
@@ -100,6 +105,7 @@ User research specialist uncovering user needs and behaviors. Expert in research
 | Design growth loops | **growth-loops** |
 | Handle legal matters | **legal-advisor** |
 | Design software licensing | **license-engineer** |
+| Run SEO / paid-ads workflows | **notfair** |
 | Shape product vision | **product-manager** |
 | Manage projects | **project-manager** |
 | Support sales | **sales-engineer** |


### PR DESCRIPTION
Thanks for maintaining this collection — it's a great resource for the Claude Code ecosystem.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** to the Business & Product section. It's an open-source set of Claude Code skills (~2.9k stars) covering three marketing domains:

- **SEO / GEO** — site analysis, keyword research, meta tags, schema markup, and geo optimization
- **Google Ads** — campaign audits, wasted-spend detection, search-term cleanup, and bid management
- **Meta Ads** — Facebook + Instagram ROAS analysis, creative fatigue detection, and audience overlap

It connects to live data through **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP**, which felt like a natural fit alongside the MCP-integrated agents already in the list.

I've placed it alphabetically between `license-engineer` and `product-manager` in both the main README and the category README, and added it to the Quick Selection Guide table.

Happy to reword, move to a different section, or trim anything that doesn't fit the list's style. Thanks again!