### PR TITLE
Add claude-code-arsenal to Meta & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Product management and business analysis.
 Agent coordination and meta-programming.
 
 - [**airis-mcp-gateway**](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%. One command to start, auto-enables servers on demand
+- [**claude-code-arsenal**](https://github.com/thespamer/claude-code-arsenal) - Six opinionated Claude Code subagents (architect, security-auditor, cost-sentinel, test-fixer, dependency-detective, commit-curator) with strict scope, read-only defaults, and a working demo project that seeds one or more issues per agent
 - [**moai-adk**](https://github.com/modu-ai/moai-adk) - SPEC-first Agentic Development Kit orchestrating 24 specialized agents with enforced Plan→Run→Sync workflow, TRUST 5 quality gates, 52 domain-specific skills, and 16-language project support
 - [**agent-installer**](categories/09-meta-orchestration/agent-installer.md) - Browse and install agents from this repository via GitHub
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.md) - Multi-agent coordinator


### PR DESCRIPTION
Adds [claude-code-arsenal](https://github.com/thespamer/claude-code-arsenal) to the **09. Meta & Orchestration** category, alongside existing external entries (`airis-mcp-gateway`, `pied-piper`).

## What it is

A collection of six specialized Claude Code subagents:

- `architect` — codebase structure review, boundary violation detection
- `security-auditor` — secrets, IAM, OWASP patterns, vulnerable deps sweep
- `cost-sentinel` — flags patterns that look fine in dev and become expensive in prod
- `test-fixer` — diagnoses failing tests across six failure modes, applies minimal fix
- `dependency-detective` — vulns, staleness, redundancy, license conflicts
- `commit-curator` — reads staged diffs, drafts Conventional Commits messages

## Why it belongs in this list

- Four of six agents are read-only by design (report findings, humans take action)
- The one that edits code (\`test-fixer\`) refuses to touch more than three files
- Each subagent follows the standard \`name\`/\`description\`/\`tools\`/\`model\` YAML frontmatter format
- Includes a working demo project (\`demo/pyorders/\`) seeded with one or more issues per agent
- Real run outputs with timings and findings captured in \`demo/DEMO.md\`, including agent screenshots
- Apache 2.0, vendor-neutral, no commercial backing

## Validation evidence

The repo includes seven screenshots of actual agent runs against the demo project (architect, security-auditor parallel + results, cost-sentinel, test-fixer, dependency-detective, commit-curator). Each agent has documented pass criteria in \`demo/DEMO.md\`.

Happy to address any feedback before merge.