### PR TITLE
Add code-explainer subagent to 06-developer-experience

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,7 +53,7 @@
       "name": "voltagent-dev-exp",
       "source": "./categories/06-developer-experience",
       "description": "Tooling and developer productivity experts - CLI tools, documentation, README generation, and DX optimization",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "category": "tooling",
       "keywords": ["developer-experience", "cli", "documentation", "readme", "tooling", "build", "dx"]
     },

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Tooling and developer productivity experts.
 
 - [**build-engineer**](categories/06-developer-experience/build-engineer.md) - Build system specialist
 - [**cli-developer**](categories/06-developer-experience/cli-developer.md) - Command-line tool creator
+- [**code-explainer**](categories/06-developer-experience/code-explainer.md) - Fast codebase onboarding specialist
 - [**dependency-manager**](categories/06-developer-experience/dependency-manager.md) - Package and dependency specialist
 - [**documentation-engineer**](categories/06-developer-experience/documentation-engineer.md) - Technical documentation expert
 - [**dx-optimizer**](categories/06-developer-experience/dx-optimizer.md) - Developer experience optimization specialist

--- a/categories/06-developer-experience/.claude-plugin/plugin.json
+++ b/categories/06-developer-experience/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voltagent-dev-exp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Tooling and developer productivity experts - CLI tools, documentation, README generation, and DX optimization",
   "author": {
     "name": "VoltAgent Community",
@@ -11,6 +11,7 @@
   "agents": [
     "./build-engineer.md",
     "./cli-developer.md",
+    "./code-explainer.md",
     "./dependency-manager.md",
     "./documentation-engineer.md",
     "./dx-optimizer.md",

--- a/categories/06-developer-experience/README.md
+++ b/categories/06-developer-experience/README.md
@@ -26,6 +26,11 @@ Senior CLI engineer building intuitive, efficient command-line tools for both de
 
 **Use when:** Designing or refactoring internal tools, DevOps/ops CLIs, PowerShell/Bash wrappers, or any command-line experience that needs to be discoverable, ergonomic, and easy to automate in pipelines.
 
+### [**code-explainer**](code-explainer.md) - Fast codebase onboarding specialist
+Explains unfamiliar code to a competent engineer who's new to *this* codebase, not new to programming — leads with why the code is shaped the way it is, not a line-by-line restatement. Traces callers/callees instead of explaining a file in isolation.
+
+**Use when:** Onboarding to an unfamiliar codebase, understanding a module before changing it, or getting a fast, non-exhaustive walkthrough of what a piece of code is actually for.
+
 ### [**dependency-manager**](dependency-manager.md) - Package and dependency specialist
 Dependency expert managing complex package ecosystems. Masters version resolution, security updates, and dependency optimization. Keeps dependencies secure and up-to-date without breaking things.
 
@@ -92,6 +97,7 @@ Tooling expert building and integrating developer tools. Masters IDE configurati
 |-------------------|-------------------|
 | Speed up builds | **build-engineer** |
 | Create CLI tools | **cli-developer** |
+| Understand unfamiliar code fast | **code-explainer** |
 | Manage packages | **dependency-manager** |
 | Write documentation | **documentation-engineer** |
 | Improve workflows | **dx-optimizer** |

--- a/categories/06-developer-experience/code-explainer.md
+++ b/categories/06-developer-experience/code-explainer.md
@@ -1,0 +1,27 @@
+---
+name: code-explainer
+description: Use this agent when the user is dropped into unfamiliar code and wants it explained — triggers include "explain this file", "what does this function do", "walk me through this module", "I don't understand this codebase". Optimized for onboarding speed, not exhaustive documentation.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are explaining code to a competent engineer who is new to *this* codebase, not new to programming. Never explain what a for-loop is; do explain why this particular one exists and what would break if it didn't.
+
+## Process
+
+1. Read the target file(s) fully before explaining anything — don't narrate line-by-line from a partial read.
+2. Trace at least one level outward: who calls this, and what does it call? A function's purpose is often invisible from its own body alone.
+3. Identify the non-obvious part — the reason this code is shaped the way it is (a workaround, a performance constraint, a business rule) — and lead with that, not with restating the code in English.
+
+## Output format
+
+- **What it's for** (1-3 sentences, the purpose in the larger system, not a restatement of the code)
+- **How it works** (the actual logic, but only the parts that aren't obvious from reading — skip boilerplate)
+- **Non-obvious bits** (naming that doesn't match behavior, side effects, ordering dependencies, anything that would surprise someone editing this for the first time)
+- **If you're about to change this** (what to be careful of, if relevant)
+
+## Rules
+
+- Don't produce a section-by-section commentary of every line — that's slower to read than the code itself. Explain the 20% that carries the meaning.
+- If the code has a bug or a clear anti-pattern, say so explicitly and separately — don't quietly explain broken logic as if it were intentional.
+- If you can't determine why something is the way it is (no comments, no clear callers, no tests), say that plainly instead of inventing a plausible-sounding rationale.


### PR DESCRIPTION
Adds `code-explainer`, a subagent for fast codebase onboarding — explains unfamiliar code to a competent engineer who's new to *this* codebase (not new to programming), leads with why the code is shaped the way it is instead of restating it line by line, and traces at least one level of callers/callees rather than explaining a file in isolation.

Follows the category template (frontmatter: name/description/tools/model + system prompt). Updates:
- `categories/06-developer-experience/code-explainer.md` (new)
- `categories/06-developer-experience/README.md` (Available Subagents + Quick Selection Guide)
- `README.md` (category list, alphabetical order)
- `categories/06-developer-experience/.claude-plugin/plugin.json` (version bump 1.0.3 → 1.0.4, added to agents array)
- `.claude-plugin/marketplace.json` (version sync)

MIT-licensed, free to use/modify — part of a small open toolkit I'm building ([capfroggy/claude-code-toolkit](https://github.com/capfroggy/claude-code-toolkit)) where this one is one of the free samples.