### PR TITLE
Add link to awesome-claude-code-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,10 @@ cp -r tools/subagent-catalog ~/.claude/commands/
 
 
 
+## 🔗 Related
+
+- [**awesome-claude-code-hooks**](https://github.com/loqimean/awesome-claude-code-hooks) - A curated list of Claude Code hook implementations and guides.
+
 ## 🤝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
This adds a link to [awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) in a new Related section near the end of the README.

It's a curated list of Claude Code hook implementations and guides. Thought it fits well alongside this subagent collection since both cover ways to extend Claude Code.