### PR TITLE
Add sandbox-runner subagent: kernel-enforced execution specialist

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Testing, security, and code quality experts.
 - [**performance-engineer**](categories/04-quality-security/performance-engineer.md) - Performance optimization expert
 - [**powershell-security-hardening**](categories/04-quality-security/powershell-security-hardening.md) - PowerShell security hardening and compliance specialist
 - [**qa-expert**](categories/04-quality-security/qa-expert.md) - Test automation specialist
+- [**sandbox-runner**](categories/04-quality-security/sandbox-runner.md) - Sandboxed execution specialist
 - [**security-auditor**](categories/04-quality-security/security-auditor.md) - Security vulnerability expert
 - [**test-automator**](categories/04-quality-security/test-automator.md) - Test automation framework expert
 - [**ui-ux-tester**](categories/04-quality-security/ui-ux-tester.md) - Exhaustive documented-flow UI tester

--- a/categories/04-quality-security/README.md
+++ b/categories/04-quality-security/README.md
@@ -91,6 +91,11 @@ Security specialist conducting thorough security audits. Masters vulnerability a
 
 **Use when:** Auditing application security, implementing security best practices, fixing vulnerabilities, designing secure architectures, or training teams on security.
 
+### [**sandbox-runner**](sandbox-runner.md) - Sandboxed execution specialist
+Execution specialist that runs untrusted agent-generated code and commands inside a kernel-enforced sandbox. Denies secret reads and off-allowlist network, blocks destructive git ops, and reports a session security recap.
+
+**Use when:** Running untrusted code or tool calls, wrapping agent CLIs in kernel isolation, enforcing egress allowlists, or auditing what a session tried to access.
+
 ### [**test-automator**](test-automator.md) - Test automation framework expert
 Automation specialist building robust test frameworks. Expert in various testing tools, patterns, and strategies. Creates maintainable, reliable automated test suites.
 
@@ -118,6 +123,7 @@ Interaction-heavy testing specialist that drives web or desktop interfaces again
 | Optimize performance | **performance-engineer** |
 | Automate testing | **qa-expert** |
 | Audit security | **security-auditor** |
+| Run untrusted code safely | **sandbox-runner** |
 | Build test frameworks | **test-automator** |
 | Exhaustively test UI flows | **ui-ux-tester** |
 

--- a/categories/04-quality-security/sandbox-runner.md
+++ b/categories/04-quality-security/sandbox-runner.md
@@ -1,0 +1,25 @@
+---
+name: sandbox-runner
+description: "Use this agent when running untrusted or semi-trusted agent-generated code, shell commands, or tool calls that need kernel-level isolation. Invoke for wrapping CLI execution in a daemon-less sandbox (Landlock/seccomp on Linux, Seatbelt on macOS), enforcing secret-denial and egress allowlists, and producing a session security recap."
+tools: Read, Bash, Glob, Grep
+model: inherit
+---
+
+You are a sandbox execution specialist. Your job is to run things safely, not to write the code being run. Default to deny: secrets stay unreadable, network stays closed except the allowlist, destructive git operations are blocked.
+
+When invoked:
+1. Identify what will run (command, agent CLI, script) and which workspace paths it legitimately needs
+2. Check whether `vetto` is installed (`vetto --version`); if missing, propose the install command for the platform and stop before executing anything untrusted
+3. Select or create the narrowest profile: project-local TOML, secrets denied (`~/.ssh`, `~/.aws`, `.env`), egress allowlist with only required hosts
+4. Run the workload via `vetto run -- <command>` or under an enabled shim (`vetto enable <agent>`), never with `--dangerously-skip-permissions` outside the sandbox
+5. On completion, report the security recap: what was denied (secret reads, egress attempts, blocked git ops) and how to roll back (`vetto undo`)
+
+Sandbox checklist:
+- Narrowest profile selected, no blanket allowlists
+- Secrets denied by the kernel, not by prompt instructions
+- Egress allowlist contains only required hosts
+- Destructive git ops (`push --force`, `reset --hard`) blocked
+- Session recap collected and surfaced
+- Rollback path (`vetto undo`) confirmed
+
+Reference implementation: [Vetto](https://github.com/shleder/vetto) (Apache-2.0, daemon-less, ~4ms startup). Disclosure: this subagent definition was contributed by the Vetto maintainer.


### PR DESCRIPTION
Adds a `sandbox-runner` subagent to Quality & Security.

Running agent-generated code and shell commands is where most agent incidents happen (secret exfiltration, unapproved egress, destructive git ops). `sandbox-runner` is a vendor-neutral execution specialist: it wraps the workload in the host kernel's isolation (Landlock/seccomp on Linux, Seatbelt on macOS), denies secrets and off-allowlist network by default, blocks destructive git ops, and reports a session security recap with a rollback path. The definition references Vetto as one implementation but the checklist (narrowest profile, kernel denial, allowlist, recap, rollback) applies to any sandbox.

Note the repo's no-promotion rule: the agent content itself is vendor-neutral; Vetto is cited once as the reference implementation with maintainer disclosure — I am the author/maintainer of Vetto (https://github.com/shleder/vetto, Apache-2.0).
