### PR TITLE
Add Wenlan – source-backed AI knowledge base and LLM wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Agent coordination and meta-programming.
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows
 - [**task-distributor**](categories/09-meta-orchestration/task-distributor.md) - Task allocation specialist
 - [**taskade**](https://github.com/taskade/mcp) - AI-powered workspace with autonomous agents, real-time collaboration, and workflow automation with MCP integration
+- [**wenlan**](https://github.com/7xuanlu/wenlan) - Source-backed AI knowledge base and LLM wiki served over MCP to coding agents
 - [**workflow-orchestrator**](categories/09-meta-orchestration/workflow-orchestrator.md) - Complex workflow automation
 
 ### [10. Research & Analysis](categories/10-research-analysis/)


### PR DESCRIPTION
Wenlan (https://wenlan.app) is a local-first, source-backed AI knowledge base and LLM wiki. It distills agent work into maintained, citation-gated wiki pages served over MCP to Claude Code, Codex, Cursor and other clients. Rust, Apache 2.0.

I believe it fits this list's 09. Meta & Orchestration section because it provides the persistent knowledge layer orchestrating subagents rely on. Happy to adjust the format or placement per maintainer feedback.